### PR TITLE
Add Barclays "agentic software factory" demo pack (TraderX feature workflow)

### DIFF
--- a/demo/barclays-agentic-factory/BACKLOG.md
+++ b/demo/barclays-agentic-factory/BACKLOG.md
@@ -1,0 +1,51 @@
+# Epic TRX-100 — Pre-trade risk controls & best-execution audit trail
+
+> **The business ask, as it actually arrives:**
+> "Compliance want us to stop traders putting on positions that blow through account limits,
+> and they want to be able to prove afterwards why any given order was accepted or rejected."
+
+That sentence is the entire input. Everything below is what comes *out* of scoping it with
+Devin in plan mode — which is the point of the first ten minutes of the demo.
+
+The epic is deliberately shaped so that it:
+
+* crosses **five services and three languages** (nothing here is a single-file change),
+* has a **regulatory driver** (MiFID II RTS 6 pre-trade controls, RTS 27/28 best-execution
+  record keeping) rather than being invented feature work,
+* contains one ticket that is a **bad idea**, so the room can watch an agent push back
+  instead of dutifully building the wrong thing.
+
+## Tickets
+
+| ID | Title | Services touched | Role that drives it | Runs in parallel? |
+| :--- | :--- | :--- | :--- | :--- |
+| [TRX-101](tickets/TRX-101-pre-trade-notional-limit.md) | Pre-trade notional limit check on order submission | trade-service | BA (plan mode) → session | yes |
+| [TRX-102](tickets/TRX-102-risk-limit-admin-api.md) | Risk limit storage + admin API | account-service, database | PM fan-out | yes |
+| [TRX-103](tickets/TRX-103-ui-rejection-reason.md) | Surface the rejection reason in the trade ticket | web-front-end (Angular + React) | PM fan-out | yes |
+| [TRX-104](tickets/TRX-104-best-execution-audit-trail.md) | Immutable best-execution audit record per order decision | trade-service, trade-processor, database | PM fan-out | yes |
+| [TRX-105](tickets/TRX-105-audit-query-api-and-blotter-tab.md) | Audit query API + "Compliance" tab on the blotter | position-service, web-front-end | PM fan-out | depends on 104 |
+| [TRX-106](tickets/TRX-106-kafka-event-sourcing.md) | "Move trade-feed to Kafka and event-source everything" | everything | **pushback beat — never built** | n/a |
+
+## Dependency shape
+
+```
+TRX-102 (limits data) ──┐
+                        ├──> TRX-101 (enforcement) ──> TRX-103 (UI reason)
+                        │
+TRX-104 (audit record) ─┴──> TRX-105 (audit API + tab)
+```
+
+101, 102, 103 and 104 are independent enough to run as **four concurrent sessions**; 105 is
+queued behind 104 on purpose, so the fleet view shows both parallelism *and* sequencing.
+
+## Acceptance criteria that apply to every ticket
+
+Written once here so each session inherits them, and so the room sees that "context must be
+explicit" is a working practice, not a slogan.
+
+1. Existing behaviour is preserved — a trade within limits still books exactly as it does today.
+2. New logic is unit tested; the service still builds with `./gradlew build`.
+3. No new runtime dependency is introduced without saying why in the PR description.
+4. Configuration (limits, feature flags) is externalised, not hard-coded.
+5. The feature can be switched off with a single flag, defaulting to **on** in dev.
+6. The PR description explains the *regulatory* reason for the change, not just the mechanics.

--- a/demo/barclays-agentic-factory/BACKLOG.md
+++ b/demo/barclays-agentic-factory/BACKLOG.md
@@ -29,14 +29,23 @@ The epic is deliberately shaped so that it:
 ## Dependency shape
 
 ```
-TRX-102 (limits data) ──┐
-                        ├──> TRX-101 (enforcement) ──> TRX-103 (UI reason)
-                        │
-TRX-104 (audit record) ─┴──> TRX-105 (audit API + tab)
+TRX-102 (limits data) ····> TRX-101 (enforcement) ····> TRX-103 (UI reason)
+
+TRX-104 (audit record) ───> TRX-105 (audit API + tab)
+
+···· soft: can be built in parallel against a stubbed interface
+───  hard: needs the upstream ticket's schema to exist first
 ```
 
-101, 102, 103 and 104 are independent enough to run as **four concurrent sessions**; 105 is
-queued behind 104 on purpose, so the fleet view shows both parallelism *and* sequencing.
+Only one of these is a hard dependency. TRX-105 genuinely cannot be built before TRX-104,
+because it queries 104's table — so it is **queued**.
+
+The others are soft. TRX-101 reads limits from configuration until TRX-102's endpoint exists,
+and TRX-103 codes against the 422 response shape written down in TRX-101 rather than waiting
+for the endpoint to be live. So 101, 102, 103 and 104 run as **four concurrent sessions**.
+
+That contrast is deliberate: the fleet view should show parallelism *and* sequencing, and the
+reason a ticket is queued should be a real schema dependency rather than caution.
 
 ## Acceptance criteria that apply to every ticket
 

--- a/demo/barclays-agentic-factory/OBJECTIONS.md
+++ b/demo/barclays-agentic-factory/OBJECTIONS.md
@@ -1,0 +1,81 @@
+# Objection handling — internal only
+
+Not for the customer deck. Answers are anchored to what this demo actually shows; anything
+we cannot back is marked as such, because in a room that has already said the other proof of
+concept "has some ways to go to prove value", a bluff costs more than a "let me come back to you".
+
+## The three hardest questions in this room
+
+**1. "We're scoping build vs. buy. What stops us building this ourselves in six months?"**
+
+The agent is the visible part and the least defensible part. What is hard to build is the
+context layer underneath it — the indexed understanding, the persistent knowledge that
+accrues per repo, the review model trained on it, and the sandbox fleet. You saw all four in
+40 minutes on a repo neither of us owns. A build programme starts that clock at zero, and the
+clock is the asset: day one is ~40% effective, day thirty is a developer with the institutional
+knowledge of someone who has been there years. Building it yourself means paying for the
+learning curve twice — once to build the platform, once to accumulate the knowledge.
+*Discovery question back:* "If you did build it, which team owns it in year two?"
+
+**2. "Where does our code go, and what can the agent touch?"**
+
+Each session runs in an ephemeral Firecracker micro-VM on AWS, fully sandboxed, with its own
+shell, browser and IDE, torn down after. Access is what you grant it — for EDP that is a
+cloned GitLab instance, with approvals in progress. Everything an agent did is auditable at
+the session level. *Trap to avoid:* do not promise on-prem or a specific region/retention
+posture on the call — that is a follow-up with our security team, and the SOC 2 / pen test
+material goes over properly rather than being paraphrased live.
+
+**3. "Your other Barclays proof of concept hasn't proved value yet. Why is this different?"**
+
+Take it straight: EDP is a migration on a hard estate, and migrations prove value at the end,
+not in the middle. Feature work proves value every week, because the unit is a merged PR
+against a real backlog. That is exactly why today was a feature and not a migration. The
+proposal is a thirty-day run against a boring, regulatory-driven backlog where the measure is
+PRs merged and review time saved — reported weekly, not at the end.
+
+## The rest
+
+**"How is this different from Copilot? We already have it."**
+Copilot makes your developer faster at the keyboard. Every agent in that tier still needs the
+developer sitting there, approving each step, on their machine. Nothing in the last 40 minutes
+ran on a laptop and nothing asked permission mid-task. Those are different products solving
+different bottlenecks — and the bottleneck in an IB backlog is not typing speed.
+
+**"What about code quality? We can't have an agent degrading a trading system."**
+Everything lands as a PR and review is mandatory — no output skips human review regardless of
+agent confidence. On top of that, automated review triages the volume. And note what the demo
+showed: on the deliberately bad ticket, it refused. The failure mode people fear is an agent
+that confidently builds the wrong thing; the control is that ambiguity escalates.
+
+**"Our codebase is 20 years old, undocumented, and half of it is COBOL-adjacent."**
+That is the best fit, not the worst. Large-scale brownfield work sitting on backlogs is the
+sweet spot. TraderX is deliberately polyglot for this reason, but it is small — if they want
+the hard version, offer the next session on their own repo.
+
+**"What happens when it gets something wrong?"**
+It shows up in review, like a junior's work, except it never gets tired at PR forty. Be
+willing to show a real recovery in the demo rather than only the happy path.
+
+**"How do we measure this? I need a number for the exec committee."**
+Resist inventing one. The measurable set from a thirty-day run: PRs merged per week against
+the target backlog, human review time per PR, cycle time from ticket to merge, and the
+proportion of tickets that needed a human to re-scope. Offer to instrument these from day one
+rather than quoting a benchmark from another customer's estate.
+
+**"Who's accountable when an agent's code causes an incident?"**
+The engineer who merged it. The agent is never accountable in the RACI — that is the design,
+not a caveat. Point at the table in `ROLE_CHANGES.md`.
+
+**"Does it work outside a small high-performing team?"**
+His actual framing, so answer it head-on: that is what the fan-out beat was. Four concurrent
+sessions, one dependency-queued, all driven off written tickets rather than tribal knowledge.
+The constraint on scale is the quality of the backlog, which is a management problem the bank
+already knows how to solve — not an agent problem.
+
+## Claims to keep hedged
+
+* "~40% on day one, 15–20 years of institutional knowledge by day thirty" — this is our
+  narrative framing, not a benchmark. Say it as framing.
+* Anything about specific Barclays approvals status beyond what Paul Sampat's team has said.
+* Any comparison to a named competitor's internals we have not verified.

--- a/demo/barclays-agentic-factory/README.md
+++ b/demo/barclays-agentic-factory/README.md
@@ -1,0 +1,37 @@
+# Barclays IB — Agentic Software Factory Demo (TraderX)
+
+A 45-minute, live, feature-development demo built on FINOS TraderX. The question it answers
+is not "can an agent write code?" — it is **"what does each role do differently the next
+morning?"** for the BA, the PM, the developer and the team lead.
+
+Audience: Steffen (Barclays Investment Bank), scoping an agentic software factory —
+build vs. buy vs. partner. He wants implementation that runs **off-machine**, outside a
+small high-performing team, at scale, with requirements genuinely separated from
+implementation.
+
+| File | What it is |
+| :--- | :--- |
+| [RUN_OF_SHOW.md](RUN_OF_SHOW.md) | Minute-by-minute script, exact prompts, fallback links |
+| [BACKLOG.md](BACKLOG.md) | The epic and its six tickets, as a BA would hand them over |
+| [tickets/](tickets) | One file per ticket — paste-ready session prompts |
+| [ROLE_CHANGES.md](ROLE_CHANGES.md) | Before/after for each role + the RACI Steffen can take to his org |
+| [OBJECTIONS.md](OBJECTIONS.md) | Prepared answers to the questions this room will actually ask |
+
+## Why TraderX
+
+TraderX is FINOS's own reference trading application — an investment-bank-shaped estate in
+miniature, and one no one in the room can wave away as a toy:
+
+* **Polyglot, exactly like the real thing** — Java/Spring (`trade-service`, `account-service`,
+  `position-service`, `trade-processor`), .NET (`people-service`), Node/NestJS
+  (`reference-data`), Node/socket.io (`trade-feed`), Angular **and** React front ends, H2/SQL.
+* **Distributed** — REST plus a message bus, so a single feature genuinely crosses service
+  and language boundaries. That is the whole point: it is where "just use Copilot" stops working.
+* **Neutral ground** — it is not the EDP proof of concept Steffen has already said "has some
+  ways to go to prove value", and it is not a Barclays repo, so nothing is off-limits on screen.
+
+## The demo in one line
+
+One epic — **pre-trade risk controls and a best-execution audit trail** — taken from a crude
+one-sentence request to merged, reviewed pull requests across five services, with a different
+human role in the driving seat at each stage.

--- a/demo/barclays-agentic-factory/ROLE_CHANGES.md
+++ b/demo/barclays-agentic-factory/ROLE_CHANGES.md
@@ -1,0 +1,85 @@
+# What each role does differently the next morning
+
+Steffen's literal ask: *take a real application, plug it into Devin, show how each role
+changes the next day.* This is the takeaway artefact for that question — the demo is the
+evidence, this is the summary he can forward inside the bank.
+
+## Business analyst
+
+| Yesterday | Tomorrow |
+| :--- | :--- |
+| Writes a spec, then defends it in refinement for two weeks | Interrogates a spec that already knows the codebase, in ten minutes |
+| Discovers cross-service impact when a developer complains | Gets the impact map before the ticket is agreed |
+| Ambiguity is resolved by whoever picks the ticket up, silently | Ambiguity is listed, in writing, before anyone builds |
+
+The BA becomes the highest-leverage role in the chain, because the quality of the scoped spec
+now determines the quality of the output directly, with nothing in between to absorb it.
+
+## Product / project manager
+
+| Yesterday | Tomorrow |
+| :--- | :--- |
+| Capacity = headcount × velocity, discovered retrospectively | Capacity = how many well-scoped tickets are in the queue |
+| Status is what people say in stand-up | Status is observable per session, continuously |
+| Parallelism is limited by who is free | Parallelism is limited by genuine dependencies |
+
+The PM's job shifts from chasing progress to **sequencing and unblocking**. The backlog stops
+being a wishlist and becomes an input queue — which also means a badly-groomed backlog now
+has an immediate, visible cost.
+
+## Developer
+
+| Yesterday | Tomorrow |
+| :--- | :--- |
+| Writes the diff | Reviews the diff, and owns whether it is right |
+| Context lives in their head and their laptop | Context is written down or the agent doesn't have it |
+| Specialises by service or language | Reviews across the estate; more full-stack by default |
+| Interrupted constantly by small tickets | Small tickets are queued, not context-switched into |
+
+This is the beat that most often lands badly if you oversell it. The honest version: the
+routine tier of the work moves, the judgement stays, and the developer's leverage goes up
+because they are now reviewing five changes in the time they used to write one. The skill
+that appreciates is **packaging context**; the skill that depreciates is typing the
+implementation of a well-understood change.
+
+## Team lead / engineering manager
+
+| Yesterday | Tomorrow |
+| :--- | :--- |
+| Standards live in a wiki nobody reads | Standards live in playbooks and knowledge, applied every time |
+| Review is the bottleneck as volume rises | Automated review triages; humans arbitrate |
+| Onboarding a new joiner takes a quarter | The estate's knowledge is written down and queryable on day one |
+| Institutional knowledge leaves when people do | Institutional knowledge accrues in the platform |
+
+The lead's job becomes **setting the constraints once** rather than enforcing them
+repeatedly — and their real deliverable becomes the team's context layer.
+
+## The operating principles to state out loud
+
+These are what make it governable, and a room scoping a factory cares more about these than
+about throughput:
+
+1. Humans own outcomes. Agents own bounded execution.
+2. Review is mandatory. Nothing ships on agent confidence.
+3. Context must be explicit — if it isn't written down and attached, the agent doesn't know it.
+4. Ambiguity escalates to humans. Uncertain agents stop and ask rather than guess and ship.
+5. Destructive permissions stay constrained. Least privilege is a hard rule.
+6. Coherence beats local speed.
+
+## RACI, for the slide he'll ask for
+
+R = responsible · A = accountable · C = consulted · I = informed
+
+| Step | BA / PM | Developer | Team lead | Agent |
+| :--- | :--- | :--- | :--- | :--- |
+| Define the outcome | R/A | C | C | I |
+| Package the context | R | A | C | I |
+| Draft the implementation plan | C | A | C | R |
+| Break into tasks | C | A | C | R |
+| Implement | I | A | I | R |
+| Review correctness | C | R/A | C | I |
+| Validate in reality | C | R/A | C | — |
+| Merge and release | C | R/A | A | — |
+
+The agent is never *accountable* for anything. That column is the answer to the governance
+question before it is asked.

--- a/demo/barclays-agentic-factory/RUN_OF_SHOW.md
+++ b/demo/barclays-agentic-factory/RUN_OF_SHOW.md
@@ -1,0 +1,163 @@
+# Run of show — 45 minutes
+
+Repo on screen: **COG-GTM/traderXCognitiondemos** (fork of FINOS TraderX).
+Everything below is live unless marked *(fallback)*.
+
+**The through-line, stated at the top and again at the end:** one feature request, four
+roles, nobody's laptop. Steffen's framing was "true separation of requirements from
+implementation" — so the demo is organised by *who is doing what*, not by *what the agent can do*.
+
+---
+
+## 0:00 — 0:03 · Frame it, then get out of the way
+
+One slide or no slide. Say this:
+
+> "Last time you saw a migration. You asked what happens to the day job — so today is a
+> feature, on a codebase neither of us owns, and I'm going to run it as four different people.
+> Watch who is doing the work at each stage."
+
+Put the epic on screen: `demo/barclays-agentic-factory/BACKLOG.md`. One sentence of business
+requirement, six tickets, five services, three languages.
+
+---
+
+## 0:03 — 0:13 · The BA · *from a sentence to a scoped spec*
+
+**Beat 1 — understanding before scoping (2 min).**
+Open the repo's indexed understanding — the architecture diagrams and service map. The line
+to use: *"nobody read this repo this morning. It has been read continuously since we indexed
+it, and what it learns persists."* Tie back to your day-1/day-30 framing from the first call.
+
+**Beat 2 — plan mode on a crude prompt (6 min).** Paste, verbatim:
+
+> Compliance want to stop traders breaching account limits, and they want to prove afterwards
+> why an order was accepted or rejected. Scope this for TraderX and tell me what you'd need
+> from me before you'd be willing to build it.
+
+While it works, narrate what a BA does with this: they are no longer writing the spec, they
+are **interrogating** one. Point at the impact map — five services, and the fact that
+`trade-service` returns 404 for every kind of rejection today, which nobody had written down
+anywhere.
+
+**Beat 3 — the pushback (5 min).** Paste TRX-106 (Kafka/event-sourcing) into plan mode. Read
+the refusal out loud. Land the principle: *ambiguity escalates to humans; scope is bounded
+before execution begins.* If Steffen is engaged, hand him the keyboard and let him write the
+bad ticket.
+
+> **What changed for the BA:** the spec is now a conversation with something that has read
+> every line of the estate, and the requirement is separated from implementation *by
+> construction* — the plan is a written artefact that exists before a single line is written.
+
+---
+
+## 0:13 — 0:22 · The PM · *fan-out and the fleet view*
+
+Kick off **four sessions at once** — TRX-101, 102, 103, 104 — each with its paste-ready prompt
+from `tickets/`. Then queue TRX-105 behind 104 and say why: 105 depends on 104's schema, and
+a factory that races four agents into the same files is not a factory.
+
+Then stop talking about the code and talk about the board. This is the PM's new instrument
+panel: what is in flight, what is blocked, what needs a human, and what it costs. The
+comparison to make out loud is with a sprint board where every card is "in progress" and the
+truth is in someone's head.
+
+*(fallback)* If the room's network or the clock is against you, the four PRs are already
+open — see **Fallback links** below. Show those instead and keep the narration identical.
+
+> **What changed for the PM:** they are sequencing and unblocking, not chasing. Capacity
+> stopped being headcount and became how many well-scoped tickets they can put into the queue.
+
+---
+
+## 0:22 — 0:33 · The developer · *review, not authorship*
+
+Open the **TRX-103** PR (UI rejection reason) — deliberately the small, visual, opinionated one,
+because that is where a human's taste genuinely beats the agent's.
+
+1. Read the PR description: it explains the regulatory reason, not just the diff.
+2. Leave a real review comment on stage. Good candidates: the shortfall should be formatted as
+   currency, or the error belongs inline rather than at the top of the form.
+3. Have it addressed — no editor opened, no local checkout, no laptop.
+4. Then run the app and put a breaching order through the ticket, so the room sees the
+   rejection reason in a browser rather than in a diff.
+
+**The tiering beat (2 min).** Switch to Devin for Desktop for one small synchronous change on
+the same repo. This is where your three-tier framing from the first call pays off: autocomplete,
+synchronous agentic IDE, asynchronous fleet — *and the same understanding of the codebase
+underneath all of them.* Steffen is scoping build-vs-buy; the thing that is hard to build is
+not the agent, it is the shared context layer.
+
+> **What changed for the developer:** the unit of work is a reviewed diff, not a keystroke.
+> The skill that matters is judgement about correctness and taste — and, increasingly, the
+> quality of the context they package up front.
+
+---
+
+## 0:33 — 0:41 · The team lead · *quality at volume, and institutional memory*
+
+**Beat 1 — Devin Review (4 min).** Five PRs landed in twenty minutes; nobody's team reviews
+that by hand. Show Devin Review's findings on the risk PRs. Be honest about what it catches
+and what it doesn't — Steffen has already told you EDP "has some ways to go", so credibility
+is the scarce resource in this room. A hedged claim you can back beats a confident one you can't.
+
+**Beat 2 — the compounding asset (4 min).** Show the knowledge notes and the playbook this
+epic produced. The argument: after this session the estate knows that rejections must be
+structured not 404, that audit records are append-only, that limits are owned by
+`account-service`. The next ticket inherits all of it. **This is the part a build-it-yourself
+programme cannot shortcut** — you can buy or build an agent, but the institutional knowledge
+only accrues by running it, and it starts accruing on day one.
+
+> **What changed for the team lead:** they set standards once, in writing, and they are
+> enforced on every PR — rather than being re-litigated in review, inconsistently, forever.
+
+---
+
+## 0:41 — 0:45 · Close on his actual question
+
+Steffen's question is build vs. buy vs. partner, at scale, off-machine. Close on the three
+things he can only get from the last 40 minutes:
+
+1. **Off-machine by default.** Every session ran in its own ephemeral micro-VM with its own
+   shell, browser and IDE. Nothing touched a developer's laptop, which is what makes it
+   auditable and what makes it scale past a small high-performing team.
+2. **Requirements separated from implementation.** The spec, the pushback and the plan were
+   all artefacts, produced before code and reviewable by people who don't write code.
+3. **It compounds.** Day one is ~40%. The reason to start on a real backlog now rather than a
+   pilot later is that the clock on institutional knowledge only starts when you begin.
+
+Then the ask: *pick one real backlog — ideally one that is regulatory-driven and boring —
+and let's run this against it for thirty days.* Offer to do the next session on a Barclays
+repo rather than TraderX, and mention that Paul Sampat's team is already through the
+approvals conversation on the GitLab side.
+
+---
+
+## Fallback links
+
+| Ticket | Pre-run PR |
+| :--- | :--- |
+| TRX-101 | *(fill in once the pre-run sessions land)* |
+| TRX-102 | *(fill in)* |
+| TRX-103 | *(fill in)* |
+| TRX-104 | *(fill in)* |
+| TRX-105 | *(fill in)* |
+
+## Pre-flight checklist
+
+* [ ] Repo indexed and up to date; architecture diagrams render.
+* [ ] TraderX running locally (`docker-compose up`) with a browser tab already on the blotter —
+      do not let the room watch a Gradle build.
+* [ ] An account seeded with a limit tight enough that a plausible order breaches it.
+* [ ] The four pre-run PRs open, plus the Devin Review comments already on them.
+* [ ] Plan-mode prompts for TRX-101 and TRX-106 in the clipboard/notes app, not typed live.
+* [ ] Devin for Desktop open on the same repo, signed in, on a second desktop.
+* [ ] Knowledge notes and the playbook visible in a tab.
+
+## Things not to do
+
+* Don't demo the migration story again. He has seen it, and he asked for the day job.
+* Don't hide the failures. If a session takes a wrong turn, show the recovery — a room
+  scoping a factory is buying the failure mode, not the happy path.
+* Don't claim a number you can't source. "~40% on day one" is your framing from call one;
+  keep it as framing, not as a benchmark.

--- a/demo/barclays-agentic-factory/RUN_OF_SHOW.md
+++ b/demo/barclays-agentic-factory/RUN_OF_SHOW.md
@@ -36,9 +36,14 @@ it, and what it learns persists."* Tie back to your day-1/day-30 framing from th
 > from me before you'd be willing to build it.
 
 While it works, narrate what a BA does with this: they are no longer writing the spec, they
-are **interrogating** one. Point at the impact map — five services, and the fact that
-`trade-service` returns 404 for every kind of rejection today, which nobody had written down
-anywhere.
+are **interrogating** one. Two things to point at when it comes back:
+
+* `trade-service` returns a 404 for every kind of rejection today — bad ticker, unknown
+  account, all of it. Nobody had written that down anywhere.
+* **There is no price data in TraderX at all.** "Stop traders breaching limits" implies a
+  notional, a notional implies a price, and this estate has none. That is the kind of thing a
+  BA usually finds out three weeks into the sprint. Here it surfaces before the ticket is
+  agreed — and it is the single best moment in the demo, so leave room for it.
 
 **Beat 3 — the pushback (5 min).** Paste TRX-106 (Kafka/event-sourcing) into plan mode. Read
 the refusal out loud. Land the principle: *ambiguity escalates to humans; scope is bounded
@@ -146,7 +151,7 @@ approvals conversation on the GitLab side.
 ## Pre-flight checklist
 
 * [ ] Repo indexed and up to date; architecture diagrams render.
-* [ ] TraderX running locally (`docker-compose up`) with a browser tab already on the blotter —
+* [ ] TraderX running locally (`docker compose up`, as per the repo README) with a browser tab already on the blotter —
       do not let the room watch a Gradle build.
 * [ ] An account seeded with a limit tight enough that a plausible order breaches it.
 * [ ] The four pre-run PRs open, plus the Devin Review comments already on them.

--- a/demo/barclays-agentic-factory/RUN_OF_SHOW.md
+++ b/demo/barclays-agentic-factory/RUN_OF_SHOW.md
@@ -140,13 +140,26 @@ approvals conversation on the GitLab side.
 
 ## Fallback links
 
+All five were pre-run from exactly the prompts in `tickets/`, so if the live fan-out stalls you
+can show these and keep the narration identical.
+
 | Ticket | Pre-run PR |
 | :--- | :--- |
-| TRX-101 | *(fill in once the pre-run sessions land)* |
-| TRX-102 | *(fill in)* |
-| TRX-103 | *(fill in)* |
-| TRX-104 | *(fill in)* |
-| TRX-105 | *(fill in)* |
+| TRX-101 | [#97 — Pre-trade notional limit check](https://github.com/COG-GTM/traderXCognitiondemos/pull/97) |
+| TRX-102 | [#98 — Risk limit storage and admin API](https://github.com/COG-GTM/traderXCognitiondemos/pull/98) |
+| TRX-103 | [#100 — Surface the rejection reason in the trade ticket](https://github.com/COG-GTM/traderXCognitiondemos/pull/100) |
+| TRX-104 | [#99 — Immutable best-execution audit record](https://github.com/COG-GTM/traderXCognitiondemos/pull/99) |
+| TRX-105 | [session](https://app.devin.ai/sessions/76a0a2788b644b68b553c9b0068b33b1) — queued behind #99, as designed |
+
+The demo pack itself is [#96](https://github.com/COG-GTM/traderXCognitiondemos/pull/96).
+
+**Worth showing on stage:** each of these PRs has a "Decisions and open questions" section
+listing the ambiguities the ticket planted and what the agent did with them. That is the
+cleanest evidence for the *ambiguity escalates to humans* principle — better than saying it.
+
+Reusable playbook for this workflow: **TraderX — Feature Delivery Workflow**
+(`playbook-47eea92ae5fa40e2b455ba37a6d883c7`, macro `!traderx_feature`). Worth opening during
+the team-lead beat as the artefact that encodes the standards.
 
 ## Pre-flight checklist
 

--- a/demo/barclays-agentic-factory/tickets/TRX-101-pre-trade-notional-limit.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-101-pre-trade-notional-limit.md
@@ -1,0 +1,63 @@
+# TRX-101 — Pre-trade notional limit check on order submission
+
+**Service:** `trade-service` (Java 21 / Spring Boot)
+**Regulatory driver:** MiFID II RTS 6 Art. 15 — pre-trade controls on order value and volume.
+**Role beat:** the BA. This is the ticket we scope live, in plan mode, from one crude sentence.
+
+## Context an agent needs
+
+`TradeOrderController.createTradeOrder` currently validates two things before publishing to
+the `/trades` topic: the ticker exists in `reference-data`, and the account exists in
+`account-service`. Both validations are inline private methods using a raw `RestTemplate`,
+and both throw `ResourceNotFoundException` on failure — so today, *every* rejection looks
+like a 404 "not found", which is useless to a trader and worse to a compliance officer.
+
+## What we want
+
+Reject an order **before** it is published when its notional value would breach the limit
+configured for that account, and reject it in a way that says *why*.
+
+* Notional = `quantity × last price` for the security. Reference data is the price source;
+  if no price is available the order is rejected as un-priceable rather than waved through.
+* Limits come from `account-service` (see TRX-102). Until that lands, read them from
+  configuration with a sane default.
+* A breach returns **422 Unprocessable Entity** with a structured body:
+  `{ "decision": "REJECTED", "reason": "NOTIONAL_LIMIT_BREACH", "limit": …, "attempted": … }`
+  — not a 404, and not a bare string.
+* Buy and sell are both in scope. Absolute notional, no netting against existing positions
+  (netting is a follow-up; say so rather than quietly implementing it).
+* Behind flag `traderx.risk.pre-trade-checks.enabled`, default `true`.
+
+## Deliberate ambiguities — we want these surfaced, not guessed
+
+These are in the ticket on purpose. A good plan asks about them; a bad agent picks one and
+ships. This is the moment the room sees the difference.
+
+* What happens to an order that breaches the limit *because* of an in-flight order that has
+  not yet been processed?
+* Is the limit per-order or per-day cumulative?
+* Who is allowed to override a breach, and is an override itself an auditable event?
+* Should `trade-processor` re-check the limit at processing time, or is a single check at
+  submission enough given the message bus is asynchronous?
+
+## Definition of done
+
+* `RiskLimitService` (or equivalent) is a separate, injectable, mockable class — the existing
+  inline validation style is explicitly *not* the pattern to copy. The current code even
+  carries a `// Move whole method to a separate class ...` comment; honour it.
+* Unit tests cover: within limit, exactly at limit, over limit, missing price, flag disabled.
+* `./gradlew :trade-service:build` passes.
+
+## Paste-ready prompts
+
+**Plan mode (the BA beat — read-only, no code):**
+
+> Compliance want to stop traders breaching account limits, and they want to prove afterwards
+> why an order was accepted or rejected. Scope this for TraderX and tell me what you'd need
+> from me before you'd be willing to build it.
+
+**Session (the execution beat):**
+
+> Implement TRX-101 from `demo/barclays-agentic-factory/tickets/TRX-101-pre-trade-notional-limit.md`
+> in COG-GTM/traderXCognitiondemos. Follow the epic-wide acceptance criteria in
+> `demo/barclays-agentic-factory/BACKLOG.md` and open a PR against `main`.

--- a/demo/barclays-agentic-factory/tickets/TRX-101-pre-trade-notional-limit.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-101-pre-trade-notional-limit.md
@@ -14,11 +14,14 @@ like a 404 "not found", which is useless to a trader and worse to a compliance o
 
 ## What we want
 
-Reject an order **before** it is published when its notional value would breach the limit
-configured for that account, and reject it in a way that says *why*.
+Reject an order **before** it is published when it would breach the limit configured for that
+account, and reject it in a way that says *why*.
 
-* Notional = `quantity × last price` for the security. Reference data is the price source;
-  if no price is available the order is rejected as un-priceable rather than waved through.
+* The limit is expressed as a **maximum order notional**. Notional = `quantity × price`.
+* **TraderX has no price data anywhere** — `reference-data` serves `{ ticker, companyName }`
+  off a flat file and nothing else, and there is no price column in `database/initialSchema.sql`.
+  So the price source is a genuine gap that has to be solved, not looked up. See the
+  ambiguities below; this is the single most important thing for the plan to surface.
 * Limits come from `account-service` (see TRX-102). Until that lands, read them from
   configuration with a sane default.
 * A breach returns **422 Unprocessable Entity** with a structured body:
@@ -33,6 +36,13 @@ configured for that account, and reject it in a way that says *why*.
 These are in the ticket on purpose. A good plan asks about them; a bad agent picks one and
 ships. This is the moment the room sees the difference.
 
+* **Where does the price come from?** There is no price source in this estate. Options: a
+  configured price map in `trade-service` (cheap, honest, obviously a stand-in); adding a price
+  field to `reference-data`'s flat file (touches another service); or a quantity-based limit
+  instead of a notional one (satisfies RTS 6 volume controls but not value controls). Each is
+  defensible; picking one silently is not. If it lands as a configured stub, that stub must be
+  visibly a stub — not something that reads like real market data.
+
 * What happens to an order that breaches the limit *because* of an in-flight order that has
   not yet been processed?
 * Is the limit per-order or per-day cumulative?
@@ -45,7 +55,7 @@ ships. This is the moment the room sees the difference.
 * `RiskLimitService` (or equivalent) is a separate, injectable, mockable class — the existing
   inline validation style is explicitly *not* the pattern to copy. The current code even
   carries a `// Move whole method to a separate class ...` comment; honour it.
-* Unit tests cover: within limit, exactly at limit, over limit, missing price, flag disabled.
+* Unit tests cover: within limit, exactly at limit, over limit, unpriceable security, flag disabled.
 * `./gradlew :trade-service:build` passes.
 
 ## Paste-ready prompts

--- a/demo/barclays-agentic-factory/tickets/TRX-102-risk-limit-admin-api.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-102-risk-limit-admin-api.md
@@ -1,0 +1,43 @@
+# TRX-102 — Risk limit storage + admin API
+
+**Services:** `account-service` (Java 21 / Spring Boot), `database` (H2)
+**Regulatory driver:** MiFID II RTS 6 Art. 15 — limits must be set, owned and changeable by
+a function independent of the trading desk.
+**Role beat:** PM fan-out. Session 2 of 4.
+
+## Context an agent needs
+
+`account-service` already owns accounts and is already the service `trade-service` calls to
+validate an account exists. The H2 schema lives under `database/`. Adding limits here keeps
+the enforcement point (trade-service) separate from the authority that sets the limit, which
+is the whole compliance argument.
+
+## What we want
+
+* A `risk_limit` table keyed on account, holding at minimum: max order notional, currency,
+  effective-from timestamp, and who set it.
+* `GET /account/{id}/risk-limit` — used by `trade-service` at enforcement time.
+* `PUT /account/{id}/risk-limit` — used by the risk function to set or amend a limit.
+* Amending a limit is itself a recorded event: never overwrite in place without leaving a
+  trail of the previous value and who changed it.
+* Seed sensible limits for the existing demo accounts so the demo has something to breach —
+  one account tight enough that a plausible-looking order trips it on stage.
+
+## Deliberate ambiguities
+
+* Should a missing limit mean "unlimited" or "reject everything"? (Compliance would say the
+  second; the demo needs the first to not break existing flows. We want this raised.)
+* Per-account, per-trader, or per-desk? The ticket says account; ask whether that is really
+  what compliance meant.
+
+## Definition of done
+
+* Liquibase/SQL change is additive — existing data and flows are untouched.
+* Unit tests cover get, put, amend-history, and missing-limit behaviour.
+* `./gradlew :account-service:build` passes.
+
+## Paste-ready prompt
+
+> Implement TRX-102 from `demo/barclays-agentic-factory/tickets/TRX-102-risk-limit-admin-api.md`
+> in COG-GTM/traderXCognitiondemos. Follow the epic-wide acceptance criteria in
+> `demo/barclays-agentic-factory/BACKLOG.md` and open a PR against `main`.

--- a/demo/barclays-agentic-factory/tickets/TRX-102-risk-limit-admin-api.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-102-risk-limit-admin-api.md
@@ -8,9 +8,12 @@ a function independent of the trading desk.
 ## Context an agent needs
 
 `account-service` already owns accounts and is already the service `trade-service` calls to
-validate an account exists. The H2 schema lives under `database/`. Adding limits here keeps
-the enforcement point (trade-service) separate from the authority that sets the limit, which
-is the whole compliance argument.
+validate an account exists. Adding limits here keeps the enforcement point (trade-service)
+separate from the authority that sets the limit, which is the whole compliance argument.
+
+The H2 schema is a single plain SQL file, `database/initialSchema.sql` — there is no Liquibase
+or Flyway in this repo. Extend that file additively. Do **not** introduce a migration framework
+for this ticket; that would trip epic acceptance criterion 3.
 
 ## What we want
 
@@ -32,7 +35,7 @@ is the whole compliance argument.
 
 ## Definition of done
 
-* Liquibase/SQL change is additive — existing data and flows are untouched.
+* The change to `database/initialSchema.sql` is additive — existing data and flows are untouched.
 * Unit tests cover get, put, amend-history, and missing-limit behaviour.
 * `./gradlew :account-service:build` passes.
 

--- a/demo/barclays-agentic-factory/tickets/TRX-103-ui-rejection-reason.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-103-ui-rejection-reason.md
@@ -1,0 +1,42 @@
+# TRX-103 — Surface the rejection reason in the trade ticket
+
+**Service:** `web-front-end` (Angular, and React where it already supports trading)
+**Role beat:** PM fan-out, session 3 of 4 — and the PR the **developer** reviews on stage.
+
+## Context an agent needs
+
+The trade ticket posts to `trade-service` `POST /trade/`. Today any failure is effectively a
+404 with a string body, so the UI can only say "something went wrong". TRX-101 introduces a
+structured 422 with `decision`, `reason`, `limit` and `attempted` fields.
+
+There are two front ends in `web-front-end/`. The Angular app is the original, feature-complete
+one including account management; the React app was a hack-day contribution and does trading
+and the blotter but not accounts. Both should handle the new response; do not "fix" the React
+app's missing account management as a side quest.
+
+## What we want
+
+* On a 422, the trade ticket shows an inline, non-modal error naming the breach in language a
+  trader would accept: the limit, what they attempted, and the shortfall.
+* The order stays in the form so it can be amended and resubmitted — do not clear it.
+* A generic failure still shows the existing generic message; the new path must not swallow
+  unrelated errors.
+* No new UI dependency. Use what the app already has.
+
+## Why this is the review beat
+
+This is a small, visual, opinionated change — exactly the kind where a human reviewer has
+taste the agent should defer to. Expect to leave a review comment on stage (wording, placement,
+or that the shortfall should be formatted as currency) and have it addressed without a human
+opening an editor.
+
+## Definition of done
+
+* Angular app builds; React app builds.
+* The error path is exercised by a test or, failing that, demonstrated in the PR with a screenshot.
+
+## Paste-ready prompt
+
+> Implement TRX-103 from `demo/barclays-agentic-factory/tickets/TRX-103-ui-rejection-reason.md`
+> in COG-GTM/traderXCognitiondemos. Follow the epic-wide acceptance criteria in
+> `demo/barclays-agentic-factory/BACKLOG.md` and open a PR against `main`.

--- a/demo/barclays-agentic-factory/tickets/TRX-104-best-execution-audit-trail.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-104-best-execution-audit-trail.md
@@ -1,0 +1,51 @@
+# TRX-104 — Immutable best-execution audit record per order decision
+
+**Services:** `trade-service`, `trade-processor`, `database`
+**Regulatory driver:** MiFID II RTS 27/28 and Art. 16(6) record keeping — the firm must be
+able to reconstruct, after the fact, why any given order was accepted or rejected, and
+retain that record for five years.
+**Role beat:** PM fan-out, session 4 of 4.
+
+## Context an agent needs
+
+Order flow today: `trade-service` validates, publishes to `/trades` on the socket.io
+`trade-feed`, and `trade-processor` consumes and books it. There is currently **no record of
+a rejection at all** — a rejected order simply never exists. That is the compliance gap, and
+it is worth saying out loud in the demo: the interesting audit record is the one for the
+order that *didn't* happen.
+
+## What we want
+
+An append-only `order_decision_audit` record written for **every** submission, accepted or
+rejected, containing at minimum:
+
+* order identity, account, security, side, quantity, computed notional and the price used;
+* the decision (`ACCEPTED` / `REJECTED`) and machine-readable reason;
+* the limit that was evaluated and its effective-from timestamp, so the record is
+  reconstructable even after the limit is later amended;
+* submitting user and a UTC timestamp with millisecond precision;
+* a correlation id that ties the submission through to the booked trade in `trade-processor`.
+
+Append-only means append-only: no update path, no delete path. If the code makes it possible
+to mutate a record, it has failed the ticket.
+
+## Deliberate ambiguities
+
+* Should the audit write be synchronous with the decision (slower, but no lost records) or
+  published to the bus (faster, but the audit trail can drop messages)? For a regulatory
+  record the trade-off matters — we want it argued, not assumed.
+* Retention: five years is the regulatory answer. Does that belong in this ticket, or is it
+  an infrastructure concern to raise and defer?
+
+## Definition of done
+
+* Additive schema change; existing flows untouched.
+* Unit tests cover an accepted decision, a rejected decision, and correlation through to
+  processing.
+* `./gradlew build` passes for both services.
+
+## Paste-ready prompt
+
+> Implement TRX-104 from `demo/barclays-agentic-factory/tickets/TRX-104-best-execution-audit-trail.md`
+> in COG-GTM/traderXCognitiondemos. Follow the epic-wide acceptance criteria in
+> `demo/barclays-agentic-factory/BACKLOG.md` and open a PR against `main`.

--- a/demo/barclays-agentic-factory/tickets/TRX-105-audit-query-api-and-blotter-tab.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-105-audit-query-api-and-blotter-tab.md
@@ -1,0 +1,32 @@
+# TRX-105 — Audit query API + "Compliance" tab on the blotter
+
+**Services:** `position-service`, `web-front-end`
+**Depends on:** TRX-104
+**Role beat:** the queued session — proof that the fleet respects dependencies rather than
+racing four agents into the same files.
+
+## Context an agent needs
+
+`position-service` is what the blotter already reads from, so the query side of the audit
+trail belongs there rather than in `trade-service`, which should stay on the hot path of
+order submission.
+
+## What we want
+
+* `GET /audit/decisions` with filters for account, security, decision and time range, paged.
+* A "Compliance" tab alongside the existing blotter tabs, listing decisions with the rejected
+  ones visually distinct — because the rejections are the ones a regulator asks about.
+* Read-only. No mutation endpoints, no delete button, no "clear" action.
+
+## Definition of done
+
+* Query is paged and indexed; a five-year table is not something you `SELECT *` from.
+* Tab renders with an empty state before any orders have been submitted.
+* Builds pass for the touched services.
+
+## Paste-ready prompt
+
+> Implement TRX-105 from `demo/barclays-agentic-factory/tickets/TRX-105-audit-query-api-and-blotter-tab.md`
+> in COG-GTM/traderXCognitiondemos. TRX-104 is a prerequisite — build on its schema rather
+> than inventing a parallel one. Follow the epic-wide acceptance criteria in
+> `demo/barclays-agentic-factory/BACKLOG.md` and open a PR against `main`.

--- a/demo/barclays-agentic-factory/tickets/TRX-106-kafka-event-sourcing.md
+++ b/demo/barclays-agentic-factory/tickets/TRX-106-kafka-event-sourcing.md
@@ -1,0 +1,46 @@
+# TRX-106 — "Move trade-feed to Kafka and event-source everything"
+
+**Status: never built. This ticket exists to be argued with.**
+
+**Role beat:** the pushback moment. This is the direct analogue of the Cassandra exchange in
+the EDP session, which Steffen has already seen land — repeating the *shape* of it on a
+different codebase is what makes it look like a property of the product rather than a lucky
+moment.
+
+## The ticket, as a well-meaning architect would write it
+
+> While we're in here adding audit records, let's do it properly: replace the socket.io
+> `trade-feed` with Kafka, event-source the whole order lifecycle, and rebuild positions as a
+> projection. Should be doable this sprint alongside the risk work.
+
+## What we expect the agent to say
+
+Not "yes". Plan mode should come back with some version of:
+
+* The audit requirement in TRX-104 does **not** need an event store. Append-only rows in the
+  existing database satisfy RTS 27/28 record keeping; event sourcing is a much larger bet
+  being smuggled in under a compliance deadline.
+* It collides with TRX-101/104, which are being built concurrently against the current
+  `Publisher`/`Subscriber` abstraction — merge conflicts across five services, and the
+  regulatory work becomes blocked on an architecture migration.
+* Positions-as-projection changes the read model the blotter and `position-service` depend on;
+  that is its own epic with its own testing story, not a line item in this one.
+* Operationally, Kafka is new infrastructure — brokers, topics, retention, DR, a team to run
+  it. TraderX's own design goal is to run on a laptop with no assumptions beyond Node, Java
+  and Python. Nothing in the stated requirement justifies breaking that.
+* A reasonable counter-proposal: keep the current bus, make the audit write synchronous and
+  append-only now, and if event sourcing is genuinely wanted, spike it separately behind the
+  existing `Publisher` interface — which is already the seam you'd migrate on.
+
+## How to run this beat
+
+Paste the ticket into **plan mode**, live, and read the response out. Do not pre-run it and
+show a screenshot — the value is that the room watches it happen to a prompt they just heard.
+
+If the room wants to test it, invite Steffen to write the bad ticket himself. It is a better
+demo when the prompt isn't yours.
+
+> **Presenter note:** the point to land afterwards is not "the agent is clever". It is that
+> **ambiguity escalates to humans** and **scope is bounded before execution starts** — which
+> is exactly the control an agentic factory needs if it is going to run outside a small
+> high-performing team.


### PR DESCRIPTION
## Summary

Docs-only. Adds `demo/barclays-agentic-factory/` — the assets for a 45-minute live demo built
on this TraderX fork, for the Barclays IB follow-up session. No application code is touched.

The demo answers the specific question that came out of the first call: *"take a real
application, plug it into Devin, show how each role changes the next day"* — developer, BA,
PM, team lead — on **feature development**, not another legacy migration.

The whole thing hangs off one epic, **TRX-100: pre-trade risk controls & best-execution audit
trail**, chosen because it crosses five services and three languages (`trade-service`,
`account-service`, `position-service`, `trade-processor`, both front ends), has a real
regulatory driver (MiFID II RTS 6 pre-trade controls, RTS 27/28 record keeping), and starts
from a single crude sentence rather than a written spec.

Two things worth knowing that aren't obvious from skimming the files:

- **TRX-106 is never meant to be built.** It's a plausible-sounding "move trade-feed to Kafka
  and event-source everything" ticket whose entire purpose is to be pasted into plan mode live
  so the room watches the agent push back — the same shape as the Cassandra pushback in the EDP
  session. The ticket file documents the expected counter-argument so the presenter knows what
  a good response looks like.
- **The ambiguities in the tickets are deliberate.** Each ticket has a "deliberate ambiguities"
  section (where the price comes from, per-order vs. cumulative limits, sync vs. async audit
  writes, missing-limit semantics) that a good plan surfaces as questions rather than guessing.
  That contrast is the demo, so please don't "helpfully" resolve them in the ticket text.

The tickets record two real gaps in the current code that the scoping beat relies on:
`TradeOrderController` throws `ResourceNotFoundException` for every validation failure, so a
bad ticker, an unknown account and (soon) a limit breach are all indistinguishable 404s to the
caller — and **TraderX has no price data anywhere**, so "limit breach" cannot mean a notional
without someone deciding where a price comes from. The second one surfaced during review of
this very PR and then again, independently, in the TRX-101 pre-run session, which refused to
invent a price feed. It is now the headline beat of the BA section.

### Contents

| File | Purpose |
| :--- | :--- |
| `README.md` | Why TraderX, what the demo is |
| `RUN_OF_SHOW.md` | Minute-by-minute script with paste-ready prompts, pre-flight checklist, fallbacks |
| `BACKLOG.md` | Epic TRX-100, six tickets, soft/hard dependency graph, epic-wide acceptance criteria |
| `tickets/TRX-101…106` | One file per ticket, each with the prompt to paste |
| `ROLE_CHANGES.md` | Before/after per role + a RACI where the agent is never *accountable* |
| `OBJECTIONS.md` | Internal prep: build-vs-buy, data boundary, "EDP hasn't proved value yet" |

### Pre-run fallback PRs

The `tickets/` files double as the actual input for pre-run sessions, so the fallbacks shown if
the live run stalls were built from exactly the prompts in the script. All four are open:
[#97](https://github.com/COG-GTM/traderXCognitiondemos/pull/97) (TRX-101),
[#98](https://github.com/COG-GTM/traderXCognitiondemos/pull/98) (TRX-102),
[#100](https://github.com/COG-GTM/traderXCognitiondemos/pull/100) (TRX-103),
[#99](https://github.com/COG-GTM/traderXCognitiondemos/pull/99) (TRX-104). TRX-105 is running
queued behind #99, as the dependency graph intends.

Each carries a "Decisions and open questions" section listing what it did with the planted
ambiguities — which is the evidence for the *ambiguity escalates to humans* principle, rather
than an assertion of it.

Reusable playbook: `playbook-47eea92ae5fa40e2b455ba37a6d883c7` (macro `!traderx_feature`).

> Note on CI: the `security/snyk` check fails with "You have used your limit of private tests",
> an org quota issue unrelated to this branch — the same failure is on unrelated PRs (e.g. #94),
> and this PR changes only markdown.


Link to Devin session: https://app.devin.ai/sessions/b1eb38a20bde4c339514728e28400759
Requested by: @chrischappell-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/96?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/traderxcognitiondemos/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->