### PR TITLE
TRX-101: Pre-trade notional limit check on order submission (MiFID II RTS 6 Art. 15)

### DIFF
--- a/trade-service/src/main/java/finos/traderx/tradeservice/TradeServiceApplication.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/TradeServiceApplication.java
@@ -2,8 +2,12 @@ package finos.traderx.tradeservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import finos.traderx.tradeservice.risk.RiskLimitProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(RiskLimitProperties.class)
 public class TradeServiceApplication {
 
 	

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -3,22 +3,25 @@ package finos.traderx.tradeservice.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 
 import finos.traderx.messaging.PubSubException;
 import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeservice.exceptions.PreTradeRiskException;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
-import finos.traderx.tradeservice.model.Account;
+import finos.traderx.tradeservice.model.RiskDecision;
 import finos.traderx.tradeservice.model.Security;
 import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.risk.RiskLimitService;
+import finos.traderx.tradeservice.service.AccountValidationService;
+import finos.traderx.tradeservice.service.ReferenceDataService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -31,85 +34,44 @@ public class TradeOrderController {
 
 	@Autowired
 	private Publisher<TradeOrder> tradePublisher;
-	
-	private RestTemplate restTemplate = new RestTemplate();
 
-	@Value("${reference.data.service.url}")
-	private String referenceDataServiceAddress;
+	@Autowired
+	private ReferenceDataService referenceDataService;
 
-	@Value("${account.service.url}")
-	private String accountServiceAddress;
+	@Autowired
+	private AccountValidationService accountValidationService;
+
+	@Autowired
+	private RiskLimitService riskLimitService;
 
 	@Operation(description = "Submit a new trade order")
 	@PostMapping("/")
 	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder) {
 		log.info("Called createTradeOrder");
-		
-		if (!validateTicker(tradeOrder.getSecurity())) 
-		{
-			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");
-		}
-		else if(!validateAccount(tradeOrder.getAccountId()))
-		{
+
+		Security security = this.referenceDataService.findSecurity(tradeOrder.getSecurity())
+			.orElseThrow(() -> new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service."));
+
+		if (!this.accountValidationService.accountExists(tradeOrder.getAccountId())) {
 			throw new ResourceNotFoundException(tradeOrder.getAccountId() + " not found in Account service.");
 		}
-		else
-		{
-			try{
-				log.info("Trade is valid. Submitting {}", tradeOrder);
-				tradePublisher.publish("/trades",tradeOrder);
-				return  ResponseEntity.ok(tradeOrder);
-			}  catch (PubSubException e){
-				throw new RuntimeException("Failed to publish trade order", e);
-			}
+
+		RiskDecision decision = this.riskLimitService.evaluate(tradeOrder, security);
+		if (decision.isRejected()) {
+			throw new PreTradeRiskException(decision);
+		}
+
+		try {
+			log.info("Trade is valid. Submitting {}", tradeOrder);
+			tradePublisher.publish("/trades", tradeOrder);
+			return ResponseEntity.ok(tradeOrder);
+		} catch (PubSubException e) {
+			throw new RuntimeException("Failed to publish trade order", e);
 		}
 	}
 
-	private boolean validateTicker(String ticker)
-	{
-		// Move whole method to a sperate class that handles all reference data 
-		// so we can mock it and run without this service up.
-		String url = this.referenceDataServiceAddress + "//stocks/" + ticker;
-		ResponseEntity<Security> response = null;
-
-		try {
-			response = this.restTemplate.getForEntity(url, Security.class);
-			log.info("Validate ticker " + response.getBody().toString());
-			return true;
-		}
-		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
-				log.info(ticker + " not found in reference data service.");
-			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
-		}
-	}		
-	
-	private boolean validateAccount(Integer id)
-	{
-		// Move whole method to a sperate class that handles all accounts 
-		// so we can mock it and run without this service up.
-
-		String url = this.accountServiceAddress + "//account/" + id;
-		ResponseEntity<Account> response = null;
-
-		try 
-		{
-				response = this.restTemplate.getForEntity(url, Account.class);
-				log.info("Validate account " + response.getBody().toString());
-				return true;
-		}
-		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
-				log.info("Account" + id + " not found in account service.");				
-			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
-		}
+	@ExceptionHandler(PreTradeRiskException.class)
+	public ResponseEntity<RiskDecision> handlePreTradeRisk(PreTradeRiskException ex) {
+		return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getDecision());
 	}
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/PreTradeRiskException.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/PreTradeRiskException.java
@@ -1,0 +1,17 @@
+package finos.traderx.tradeservice.exceptions;
+
+import finos.traderx.tradeservice.model.RiskDecision;
+
+public class PreTradeRiskException extends RuntimeException {
+
+	private final RiskDecision decision;
+
+	public PreTradeRiskException(RiskDecision decision) {
+		super(decision.toString());
+		this.decision = decision;
+	}
+
+	public RiskDecision getDecision() {
+		return decision;
+	}
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/RiskDecision.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/RiskDecision.java
@@ -1,0 +1,61 @@
+package finos.traderx.tradeservice.model;
+
+import java.math.BigDecimal;
+
+/**
+ * Outcome of the pre-trade risk evaluation of a single order. Serialised as the
+ * response body when an order is rejected.
+ */
+public class RiskDecision {
+
+    public static final String REASON_WITHIN_LIMIT = "WITHIN_LIMIT";
+    public static final String REASON_CHECKS_DISABLED = "PRE_TRADE_CHECKS_DISABLED";
+    public static final String REASON_NOTIONAL_LIMIT_BREACH = "NOTIONAL_LIMIT_BREACH";
+    public static final String REASON_PRICE_UNAVAILABLE = "PRICE_UNAVAILABLE";
+
+    private final String decision;
+    private final String reason;
+    private final BigDecimal limit;
+    private final BigDecimal attempted;
+
+    private RiskDecision(String decision, String reason, BigDecimal limit, BigDecimal attempted) {
+        this.decision = decision;
+        this.reason = reason;
+        this.limit = limit;
+        this.attempted = attempted;
+    }
+
+    public static RiskDecision accepted(String reason, BigDecimal limit, BigDecimal attempted) {
+        return new RiskDecision("ACCEPTED", reason, limit, attempted);
+    }
+
+    public static RiskDecision rejected(String reason, BigDecimal limit, BigDecimal attempted) {
+        return new RiskDecision("REJECTED", reason, limit, attempted);
+    }
+
+    public String getDecision() {
+        return decision;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public BigDecimal getLimit() {
+        return limit;
+    }
+
+    public BigDecimal getAttempted() {
+        return attempted;
+    }
+
+    public boolean isRejected() {
+        return "REJECTED".equals(decision);
+    }
+
+    @Override
+    public String toString() {
+        return "RiskDecision{decision=" + decision + ", reason=" + reason
+                + ", limit=" + limit + ", attempted=" + attempted + "}";
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/RiskDecision.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/RiskDecision.java
@@ -2,6 +2,8 @@ package finos.traderx.tradeservice.model;
 
 import java.math.BigDecimal;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Outcome of the pre-trade risk evaluation of a single order. Serialised as the
  * response body when an order is rejected.
@@ -12,6 +14,7 @@ public class RiskDecision {
     public static final String REASON_CHECKS_DISABLED = "PRE_TRADE_CHECKS_DISABLED";
     public static final String REASON_NOTIONAL_LIMIT_BREACH = "NOTIONAL_LIMIT_BREACH";
     public static final String REASON_PRICE_UNAVAILABLE = "PRICE_UNAVAILABLE";
+    public static final String REASON_INVALID_QUANTITY = "INVALID_QUANTITY";
 
     private final String decision;
     private final String reason;
@@ -49,6 +52,7 @@ public class RiskDecision {
         return attempted;
     }
 
+    @JsonIgnore
     public boolean isRejected() {
         return "REJECTED".equals(decision);
     }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/Security.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/Security.java
@@ -1,8 +1,14 @@
 package finos.traderx.tradeservice.model;
 
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Security {
     private String ticker;
     private String companyName;
+    private BigDecimal lastPrice;
 
     public Security()
     {
@@ -11,8 +17,14 @@ public class Security {
 
     public Security(String ticker, String companyName)
     {
+        this(ticker, companyName, null);
+    }
+
+    public Security(String ticker, String companyName, BigDecimal lastPrice)
+    {
         this.ticker = ticker;
         this.companyName = companyName;
+        this.lastPrice = lastPrice;
     }
 
     public String getTicker()
@@ -20,8 +32,34 @@ public class Security {
         return ticker;
     }
 
+    public void setTicker(String ticker)
+    {
+        this.ticker = ticker;
+    }
+
     public String getcompanyName()
     {
         return companyName; 
+    }
+
+    public void setcompanyName(String companyName)
+    {
+        this.companyName = companyName;
+    }
+
+    public BigDecimal getLastPrice()
+    {
+        return lastPrice;
+    }
+
+    public void setLastPrice(BigDecimal lastPrice)
+    {
+        this.lastPrice = lastPrice;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Security{ticker=" + ticker + ", companyName=" + companyName + ", lastPrice=" + lastPrice + "}";
     }
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitProperties.java
@@ -1,0 +1,92 @@
+package finos.traderx.tradeservice.risk;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "traderx.risk")
+public class RiskLimitProperties {
+
+    private final PreTradeChecks preTradeChecks = new PreTradeChecks();
+    private final NotionalLimit notionalLimit = new NotionalLimit();
+    private final Prices prices = new Prices();
+
+    public PreTradeChecks getPreTradeChecks() {
+        return preTradeChecks;
+    }
+
+    public NotionalLimit getNotionalLimit() {
+        return notionalLimit;
+    }
+
+    public Prices getPrices() {
+        return prices;
+    }
+
+    public static class PreTradeChecks {
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Per-order notional limits. Sourced from configuration until account-service
+     * owns them (TRX-102).
+     */
+    public static class NotionalLimit {
+        private BigDecimal defaultLimit = new BigDecimal("1000000");
+        private Map<Integer, BigDecimal> perAccount = new HashMap<>();
+
+        public BigDecimal getDefaultLimit() {
+            return defaultLimit;
+        }
+
+        public void setDefaultLimit(BigDecimal defaultLimit) {
+            this.defaultLimit = defaultLimit;
+        }
+
+        public Map<Integer, BigDecimal> getPerAccount() {
+            return perAccount;
+        }
+
+        public void setPerAccount(Map<Integer, BigDecimal> perAccount) {
+            this.perAccount = perAccount;
+        }
+
+        public BigDecimal limitFor(Integer accountId) {
+            return perAccount.getOrDefault(accountId, defaultLimit);
+        }
+    }
+
+    /**
+     * Price fallbacks used while reference-data does not publish a last price.
+     */
+    public static class Prices {
+        private BigDecimal fallbackLastPrice;
+        private Map<String, BigDecimal> perTicker = new HashMap<>();
+
+        public BigDecimal getFallbackLastPrice() {
+            return fallbackLastPrice;
+        }
+
+        public void setFallbackLastPrice(BigDecimal fallbackLastPrice) {
+            this.fallbackLastPrice = fallbackLastPrice;
+        }
+
+        public Map<String, BigDecimal> getPerTicker() {
+            return perTicker;
+        }
+
+        public void setPerTicker(Map<String, BigDecimal> perTicker) {
+            this.perTicker = perTicker;
+        }
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitService.java
@@ -1,0 +1,64 @@
+package finos.traderx.tradeservice.risk;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import finos.traderx.tradeservice.model.RiskDecision;
+import finos.traderx.tradeservice.model.Security;
+import finos.traderx.tradeservice.model.TradeOrder;
+
+/**
+ * Pre-trade notional check (MiFID II RTS 6 Art. 15). Evaluates a single order
+ * in isolation: absolute notional, no netting against existing or in-flight
+ * positions.
+ */
+@Service
+public class RiskLimitService {
+
+	private static final Logger log = LoggerFactory.getLogger(RiskLimitService.class);
+
+	private final RiskLimitProperties properties;
+
+	public RiskLimitService(RiskLimitProperties properties) {
+		this.properties = properties;
+	}
+
+	public RiskDecision evaluate(TradeOrder tradeOrder, Security security) {
+		if (!properties.getPreTradeChecks().isEnabled()) {
+			return RiskDecision.accepted(RiskDecision.REASON_CHECKS_DISABLED, null, null);
+		}
+
+		BigDecimal limit = properties.getNotionalLimit().limitFor(tradeOrder.getAccountId());
+		Optional<BigDecimal> price = lastPriceFor(security, tradeOrder.getSecurity());
+
+		if (price.isEmpty()) {
+			log.info("No price available for {}; rejecting order as un-priceable.", tradeOrder.getSecurity());
+			return RiskDecision.rejected(RiskDecision.REASON_PRICE_UNAVAILABLE, limit, null);
+		}
+
+		BigDecimal quantity = BigDecimal.valueOf(tradeOrder.getQuantity()).abs();
+		BigDecimal attempted = price.get().multiply(quantity);
+
+		if (attempted.compareTo(limit) > 0) {
+			log.info("Order {} breaches notional limit: attempted {} vs limit {}", tradeOrder.getId(), attempted, limit);
+			return RiskDecision.rejected(RiskDecision.REASON_NOTIONAL_LIMIT_BREACH, limit, attempted);
+		}
+		return RiskDecision.accepted(RiskDecision.REASON_WITHIN_LIMIT, limit, attempted);
+	}
+
+	private Optional<BigDecimal> lastPriceFor(Security security, String ticker) {
+		if (security != null && security.getLastPrice() != null) {
+			return Optional.of(security.getLastPrice());
+		}
+		RiskLimitProperties.Prices prices = properties.getPrices();
+		BigDecimal configured = prices.getPerTicker().get(ticker);
+		if (configured == null) {
+			configured = prices.getFallbackLastPrice();
+		}
+		return Optional.ofNullable(configured);
+	}
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/risk/RiskLimitService.java
@@ -33,6 +33,12 @@ public class RiskLimitService {
 		}
 
 		BigDecimal limit = properties.getNotionalLimit().limitFor(tradeOrder.getAccountId());
+
+		if (tradeOrder.getQuantity() == null || tradeOrder.getQuantity() == 0) {
+			log.info("Order {} has no usable quantity; cannot evaluate notional.", tradeOrder.getId());
+			return RiskDecision.rejected(RiskDecision.REASON_INVALID_QUANTITY, limit, null);
+		}
+
 		Optional<BigDecimal> price = lastPriceFor(security, tradeOrder.getSecurity());
 
 		if (price.isEmpty()) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/service/AccountValidationService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/service/AccountValidationService.java
@@ -1,0 +1,42 @@
+package finos.traderx.tradeservice.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import finos.traderx.tradeservice.model.Account;
+
+/**
+ * Access to the account-service. Extracted from TradeOrderController so it can
+ * be mocked and so trade-service can be tested without account-service up.
+ */
+@Service
+public class AccountValidationService {
+
+	private static final Logger log = LoggerFactory.getLogger(AccountValidationService.class);
+
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	@Value("${account.service.url}")
+	private String accountServiceAddress;
+
+	public boolean accountExists(Integer id) {
+		String url = this.accountServiceAddress + "//account/" + id;
+		try {
+			ResponseEntity<Account> response = this.restTemplate.getForEntity(url, Account.class);
+			log.info("Validate account {}", response.getBody());
+			return true;
+		} catch (HttpClientErrorException ex) {
+			if (ex.getStatusCode().value() == 404) {
+				log.info("Account {} not found in account service.", id);
+			} else {
+				log.error(ex.getMessage());
+			}
+			return false;
+		}
+	}
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/service/ReferenceDataService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/service/ReferenceDataService.java
@@ -1,0 +1,44 @@
+package finos.traderx.tradeservice.service;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import finos.traderx.tradeservice.model.Security;
+
+/**
+ * Access to the reference-data service. Extracted from TradeOrderController so
+ * it can be mocked and so trade-service can be tested without reference-data up.
+ */
+@Service
+public class ReferenceDataService {
+
+	private static final Logger log = LoggerFactory.getLogger(ReferenceDataService.class);
+
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	@Value("${reference.data.service.url}")
+	private String referenceDataServiceAddress;
+
+	public Optional<Security> findSecurity(String ticker) {
+		String url = this.referenceDataServiceAddress + "//stocks/" + ticker;
+		try {
+			ResponseEntity<Security> response = this.restTemplate.getForEntity(url, Security.class);
+			log.info("Validate ticker {}", response.getBody());
+			return Optional.ofNullable(response.getBody());
+		} catch (HttpClientErrorException ex) {
+			if (ex.getStatusCode().value() == 404) {
+				log.info("{} not found in reference data service.", ticker);
+			} else {
+				log.error(ex.getMessage());
+			}
+			return Optional.empty();
+		}
+	}
+}

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -10,4 +10,11 @@ trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:1808
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000
 
+# Pre-trade risk controls (MiFID II RTS 6 Art. 15). Single kill switch, on by default.
+traderx.risk.pre-trade-checks.enabled=${PRE_TRADE_CHECKS_ENABLED:true}
+# Per-order notional limit, in the security's currency. Moves to account-service under TRX-102.
+traderx.risk.notional-limit.default-limit=${DEFAULT_NOTIONAL_LIMIT:1000000}
+# Placeholder last price: reference-data does not yet publish prices. Remove once it does.
+traderx.risk.prices.fallback-last-price=${FALLBACK_LAST_PRICE:100.00}
+
 logging.level.root=info

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerTest.java
@@ -1,0 +1,83 @@
+package finos.traderx.tradeservice.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeservice.model.Security;
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.risk.RiskLimitProperties;
+import finos.traderx.tradeservice.risk.RiskLimitService;
+import finos.traderx.tradeservice.service.AccountValidationService;
+import finos.traderx.tradeservice.service.ReferenceDataService;
+
+class TradeOrderControllerTest {
+
+	private static final String ORDER_JSON =
+		"{\"id\":\"order-1\",\"accountId\":42,\"security\":\"AAPL\",\"side\":\"Buy\",\"quantity\":11}";
+
+	@SuppressWarnings("unchecked")
+	private final Publisher<TradeOrder> publisher = mock(Publisher.class);
+	private final ReferenceDataService referenceDataService = mock(ReferenceDataService.class);
+	private final AccountValidationService accountValidationService = mock(AccountValidationService.class);
+
+	private RiskLimitProperties properties;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		properties = new RiskLimitProperties();
+		properties.getNotionalLimit().setDefaultLimit(new BigDecimal("1000"));
+
+		TradeOrderController controller = new TradeOrderController();
+		ReflectionTestUtils.setField(controller, "tradePublisher", publisher);
+		ReflectionTestUtils.setField(controller, "referenceDataService", referenceDataService);
+		ReflectionTestUtils.setField(controller, "accountValidationService", accountValidationService);
+		ReflectionTestUtils.setField(controller, "riskLimitService", new RiskLimitService(properties));
+
+		when(referenceDataService.findSecurity("AAPL"))
+			.thenReturn(Optional.of(new Security("AAPL", "Apple", new BigDecimal("100"))));
+		when(accountValidationService.accountExists(42)).thenReturn(true);
+
+		mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+	}
+
+	@Test
+	void breachReturns422WithStructuredBody() throws Exception {
+		mockMvc.perform(post("/trade/").contentType(MediaType.APPLICATION_JSON).content(ORDER_JSON))
+			.andExpect(status().isUnprocessableEntity())
+			.andExpect(jsonPath("$.decision").value("REJECTED"))
+			.andExpect(jsonPath("$.reason").value("NOTIONAL_LIMIT_BREACH"))
+			.andExpect(jsonPath("$.limit").value(1000))
+			.andExpect(jsonPath("$.attempted").value(1100));
+
+		verify(publisher, never()).publish(any(), any());
+	}
+
+	@Test
+	void orderWithinLimitStillBooks() throws Exception {
+		properties.getNotionalLimit().setDefaultLimit(new BigDecimal("100000"));
+
+		mockMvc.perform(post("/trade/").contentType(MediaType.APPLICATION_JSON).content(ORDER_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.security").value("AAPL"));
+
+		verify(publisher).publish(any(), any());
+	}
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/risk/RiskLimitServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/risk/RiskLimitServiceTest.java
@@ -112,6 +112,17 @@ class RiskLimitServiceTest {
 	}
 
 	@Test
+	void rejectsOrderWithoutQuantity() {
+		TradeOrder order = new TradeOrder();
+
+		RiskDecision decision = service.evaluate(order, priced("100"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(RiskDecision.REASON_INVALID_QUANTITY, decision.getReason());
+		assertNull(decision.getAttempted());
+	}
+
+	@Test
 	void acceptsEverythingWhenFlagDisabled() {
 		properties.getPreTradeChecks().setEnabled(false);
 

--- a/trade-service/src/test/java/finos/traderx/tradeservice/risk/RiskLimitServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/risk/RiskLimitServiceTest.java
@@ -1,0 +1,123 @@
+package finos.traderx.tradeservice.risk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import finos.traderx.tradeservice.model.RiskDecision;
+import finos.traderx.tradeservice.model.Security;
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.TradeSide;
+
+class RiskLimitServiceTest {
+
+	private RiskLimitProperties properties;
+	private RiskLimitService service;
+
+	@BeforeEach
+	void setUp() {
+		properties = new RiskLimitProperties();
+		properties.getNotionalLimit().setDefaultLimit(new BigDecimal("1000"));
+		service = new RiskLimitService(properties);
+	}
+
+	private TradeOrder order(int quantity, TradeSide side) {
+		return new TradeOrder("order-1", 42, "AAPL", side, quantity);
+	}
+
+	private Security priced(String price) {
+		return new Security("AAPL", "Apple", new BigDecimal(price));
+	}
+
+	@Test
+	void acceptsOrderWithinLimit() {
+		RiskDecision decision = service.evaluate(order(5, TradeSide.Buy), priced("100"));
+
+		assertFalse(decision.isRejected());
+		assertEquals(RiskDecision.REASON_WITHIN_LIMIT, decision.getReason());
+		assertEquals(0, decision.getAttempted().compareTo(new BigDecimal("500")));
+	}
+
+	@Test
+	void acceptsOrderExactlyAtLimit() {
+		RiskDecision decision = service.evaluate(order(10, TradeSide.Buy), priced("100"));
+
+		assertFalse(decision.isRejected());
+		assertEquals(0, decision.getAttempted().compareTo(new BigDecimal("1000")));
+	}
+
+	@Test
+	void rejectsOrderOverLimit() {
+		RiskDecision decision = service.evaluate(order(11, TradeSide.Buy), priced("100"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(RiskDecision.REASON_NOTIONAL_LIMIT_BREACH, decision.getReason());
+		assertEquals(0, decision.getLimit().compareTo(new BigDecimal("1000")));
+		assertEquals(0, decision.getAttempted().compareTo(new BigDecimal("1100")));
+	}
+
+	@Test
+	void rejectsSellOrderOverLimitOnAbsoluteNotional() {
+		RiskDecision decision = service.evaluate(order(11, TradeSide.Sell), priced("100"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(RiskDecision.REASON_NOTIONAL_LIMIT_BREACH, decision.getReason());
+	}
+
+	@Test
+	void rejectsOrderWithNoPriceAvailable() {
+		RiskDecision decision = service.evaluate(order(1, TradeSide.Buy), new Security("AAPL", "Apple"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(RiskDecision.REASON_PRICE_UNAVAILABLE, decision.getReason());
+		assertNull(decision.getAttempted());
+	}
+
+	@Test
+	void fallsBackToConfiguredPriceWhenReferenceDataHasNone() {
+		properties.getPrices().setFallbackLastPrice(new BigDecimal("50"));
+
+		RiskDecision decision = service.evaluate(order(30, TradeSide.Buy), new Security("AAPL", "Apple"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(RiskDecision.REASON_NOTIONAL_LIMIT_BREACH, decision.getReason());
+		assertEquals(0, decision.getAttempted().compareTo(new BigDecimal("1500")));
+	}
+
+	@Test
+	void perTickerPriceOverridesFallback() {
+		properties.getPrices().setFallbackLastPrice(new BigDecimal("50"));
+		properties.getPrices().getPerTicker().put("AAPL", new BigDecimal("10"));
+
+		RiskDecision decision = service.evaluate(order(30, TradeSide.Buy), new Security("AAPL", "Apple"));
+
+		assertFalse(decision.isRejected());
+		assertEquals(0, decision.getAttempted().compareTo(new BigDecimal("300")));
+	}
+
+	@Test
+	void perAccountLimitOverridesDefault() {
+		properties.getNotionalLimit().getPerAccount().put(42, new BigDecimal("100"));
+
+		RiskDecision decision = service.evaluate(order(5, TradeSide.Buy), priced("100"));
+
+		assertTrue(decision.isRejected());
+		assertEquals(0, decision.getLimit().compareTo(new BigDecimal("100")));
+	}
+
+	@Test
+	void acceptsEverythingWhenFlagDisabled() {
+		properties.getPreTradeChecks().setEnabled(false);
+
+		RiskDecision decision = service.evaluate(order(1000000, TradeSide.Buy), new Security("AAPL", "Apple"));
+
+		assertFalse(decision.isRejected());
+		assertEquals(RiskDecision.REASON_CHECKS_DISABLED, decision.getReason());
+	}
+}


### PR DESCRIPTION
## Summary

TRX-101 — pre-trade notional limit check on order submission in `trade-service`.

**Why (regulatory driver).** MiFID II RTS 6 Art. 15 requires an investment firm operating an electronic trading system to apply *pre-trade* controls on order value and volume — the order must be blocked **before** it reaches the market, not reconciled after the fact. Equally, an "order value" control that fires but cannot say *what* it rejected and *against which limit* does not satisfy the firm's record-keeping and supervisory obligations (RTS 6 Art. 15 & Annex, and the best-execution record keeping under RTS 27/28 that TRX-104 builds on). Today every rejection in `TradeOrderController` — unknown ticker, unknown account — surfaces as a `404 "not found"`, which is unusable evidence for a compliance officer and unactionable for a trader. This change adds the limit control and gives the rejection a machine-readable, auditable shape.

**What changed.** Order submission now runs a third check after ticker/account validation:

```java
Security security = referenceDataService.findSecurity(order.getSecurity())
        .orElseThrow(() -> new ResourceNotFoundException(...));   // unchanged 404
if (!accountValidationService.accountExists(order.getAccountId())) { ... }   // unchanged 404

RiskDecision decision = riskLimitService.evaluate(order, security);
if (decision.isRejected()) throw new PreTradeRiskException(decision);        // 422
tradePublisher.publish("/trades", order);
```

A breach never reaches the `/trades` topic and returns **422**:

```json
{ "decision": "REJECTED", "reason": "NOTIONAL_LIMIT_BREACH", "limit": 1000, "attempted": 1100 }
```

`notional = |quantity| × lastPrice`, buy and sell both in scope, **absolute — no netting** against existing or in-flight positions (netting is deliberately *not* implemented here; see below). At the limit is accepted, over the limit is rejected. An un-priceable order is rejected (`reason: PRICE_UNAVAILABLE`) rather than waved through; an order with no usable quantity is rejected as `INVALID_QUANTITY` rather than blowing up on a null unbox.

**Structure.** Per the DoD, the existing inline-private-method style is not copied, and the `// Move whole method to a separate class ...` comments in the controller are honoured: reference-data and account lookups are now `ReferenceDataService` / `AccountValidationService`, and the risk logic is `RiskLimitService` — three injectable, mockable beans. The controller no longer owns a `RestTemplate`. `ReferenceDataService.findSecurity` returns the `Security` instead of a boolean, so the price is fetched by the call that was already being made — no extra round trip.

**Configuration** (`RiskLimitProperties`, prefix `traderx.risk`, externalised, all env-overridable):

| Property | Default | Note |
| :--- | :--- | :--- |
| `traderx.risk.pre-trade-checks.enabled` | `true` | single kill switch; off ⇒ every order accepted, behaviour identical to today |
| `traderx.risk.notional-limit.default-limit` | `1000000` | moves to `account-service` under TRX-102 |
| `traderx.risk.notional-limit.per-account.{id}` | — | interim per-account override |
| `traderx.risk.prices.fallback-last-price` | `100.00` | see decision 1 |
| `traderx.risk.prices.per-ticker.{TICKER}` | — | see decision 1 |

No new runtime dependency. `./gradlew :trade-service:build` passes; unit tests cover within limit, exactly at limit, over limit, sell side, missing price, config fallback, per-account override, flag disabled, plus a `MockMvc` test asserting the 422 body shape and that a within-limit order still publishes.

## Decisions and open questions

The ticket flagged four ambiguities on purpose. I have **not** silently resolved them — each is listed with the smallest defensible thing I did instead.

**Decisions I made (small, reversible, please sanity-check):**

1. **Where the price comes from.** The ticket names reference-data as the price source, but `reference-data` does not currently publish a price at all — its `Stock` is `{ ticker, companyName }`. Implementing "no price ⇒ reject" literally would reject **every** order in dev and break epic AC #1. So: `Security` gains an optional `lastPrice` that is used whenever reference-data starts returning it, with a configured price as a fallback (`per-ticker`, then `fallback-last-price`, default `100.00` in dev). If neither exists, the order is rejected as un-priceable, as specified. **A configured constant is not a market price and must not ship to any environment where the limit is a real control** — reference-data (or a market-data source) needs to serve a real last price, which I think is a missing ticket in this epic.
2. **At the limit is accepted.** `attempted > limit` breaches; `attempted == limit` books. Ordinary limit semantics, but worth a compliance nod.
3. **`PRICE_UNAVAILABLE` is also a 422**, with `attempted: null`. It is a rejection, not a "not found", so it should not be a 404 — but it is a distinct `reason` so the UI (TRX-103) and audit trail (TRX-104) can tell "you are over your limit" apart from "we could not price this".
4. **Limits are read from config, not `account-service`** — as the ticket instructs, pending TRX-102. `limitFor(accountId)` is the single seam that TRX-102 replaces.

**Questions I am not willing to guess — these need a human (compliance, ideally, not just eng):**

1. **In-flight orders.** An order that is within limit on its own but breaches once an unprocessed in-flight order is counted is **currently accepted**. Fixing it properly means reserving notional at submission and releasing it on fill/reject — i.e. state in `trade-service`, and a policy decision about what happens if a reservation is never released. Which behaviour does compliance expect?
2. **Per-order or per-day cumulative?** Implemented as **per-order**, because that is the only thing the current data supports. RTS 6 firms typically run both. Cumulative needs a definition of the window (trade date? rolling 24h? per venue?) and a store of the day's activity — a separate ticket, not a variant of this one.
3. **Overrides.** There is **no override path** in this PR. Who may override (trader? desk head? risk only?), does an override apply to one order or raise the limit, and is the override itself an auditable event with an approver identity? That last part is a regulatory question, not a UX one, and it likely belongs with TRX-104's audit record.
4. **Re-check in `trade-processor`?** The bus is asynchronous, so a check at submission is a check against state that may be stale by the time the trade books. This PR checks **only at submission**. Whether the processor must re-check (and what it does when a re-check fails after the client got a 200) is a design decision that changes TRX-104's audit model, so I have left it open.

**Deliberately out of scope:** netting against existing positions, the UI surfacing of `reason` (TRX-103), and the immutable audit record of each decision (TRX-104). The `RiskDecision` object is shaped so TRX-104 can persist it as-is for accepted orders too — `evaluate` already returns an `ACCEPTED` decision carrying `limit` and `attempted`, which is the "prove why an order was accepted" half of the compliance ask.


Link to Devin session: https://app.devin.ai/sessions/c05e41042b9d406bbc95c29d4f5cea7d
Requested by: @chrischappell-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/97?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/traderxcognitiondemos/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->