### PR TITLE
TRX-102: risk limit storage and admin API in account-service

### DIFF
--- a/account-service/openapi.yaml
+++ b/account-service/openapi.yaml
@@ -209,7 +209,10 @@ paths:
       tags:
         - risk-limit-controller
       operationId: getRiskLimitHistory
-      description: "Append-only trail of every limit value that has been in force, most recent first"
+      description: >-
+        Append-only trail of every limit value that has been in force, most recent first.
+        Returns an empty list when risk limits are switched off
+        (traderx.risk-limit.enabled=false), matching the read path's fail-open behaviour.
       parameters:
         - name: id
           in: path

--- a/account-service/openapi.yaml
+++ b/account-service/openapi.yaml
@@ -229,6 +229,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/RiskLimitHistory"
+        "404":
+          description: Unknown account
 components:
   schemas:
     RiskLimitRequest:

--- a/account-service/openapi.yaml
+++ b/account-service/openapi.yaml
@@ -203,7 +203,9 @@ paths:
         "404":
           description: Unknown account
         "503":
-          description: Risk limits are switched off (traderx.risk-limit.enabled=false)
+          description: >-
+            Risk limits are switched off (traderx.risk-limit.enabled=false). Checked before the
+            account is looked up, so a 503 says nothing about whether the account exists.
   /account/{id}/risk-limit/history:
     get:
       tags:
@@ -274,6 +276,9 @@ components:
         effectiveFrom:
           type: string
           format: date-time
+          description: >-
+            When the value shown here took effect, i.e. the latest amendment - not when the account
+            first came under limit control. Use the history endpoint for that.
         setBy:
           type: string
           example: risk.control@traderx

--- a/account-service/openapi.yaml
+++ b/account-service/openapi.yaml
@@ -144,8 +144,164 @@ paths:
             "application/json":
               schema:
                 $ref: "#/components/schemas/Account"
+  /account/{id}/risk-limit:
+    get:
+      tags:
+        - risk-limit-controller
+      operationId: getRiskLimit
+      description: >-
+        Gets the pre-trade risk limit in force for an account. Returns 200 with
+        limitPresent=false when the account has no limit on file; callers must then honour
+        missingLimitPolicy.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/RiskLimitView"
+        "404":
+          description: Unknown account
+    put:
+      tags:
+        - risk-limit-controller
+      operationId: setRiskLimit
+      description: >-
+        Sets or amends the risk limit for an account. Used by the risk function, which under
+        MiFID II RTS 6 Art. 15 must be independent of the trading desk. Every accepted change
+        appends a row to the limit history.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RiskLimitRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/RiskLimitView"
+        "400":
+          description: Invalid limit payload
+        "404":
+          description: Unknown account
+        "503":
+          description: Risk limits are switched off (traderx.risk-limit.enabled=false)
+  /account/{id}/risk-limit/history:
+    get:
+      tags:
+        - risk-limit-controller
+      operationId: getRiskLimitHistory
+      description: "Append-only trail of every limit value that has been in force, most recent first"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/json":
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RiskLimitHistory"
 components:
   schemas:
+    RiskLimitRequest:
+      type: object
+      properties:
+        maxOrderNotional:
+          type: number
+          example: 50000.00
+        currency:
+          type: string
+          example: USD
+        effectiveFrom:
+          type: string
+          format: date-time
+        setBy:
+          type: string
+          example: risk.control@traderx
+        reason:
+          type: string
+          example: "Client uplift approved by head of risk"
+    RiskLimitView:
+      type: object
+      properties:
+        accountId:
+          type: integer
+          format: int32
+          example: 11413
+        limitPresent:
+          type: boolean
+          example: true
+        missingLimitPolicy:
+          type: string
+          enum: [UNLIMITED, REJECT]
+          example: UNLIMITED
+        maxOrderNotional:
+          type: number
+          example: 50000.00
+        currency:
+          type: string
+          example: USD
+        effectiveFrom:
+          type: string
+          format: date-time
+        setBy:
+          type: string
+          example: risk.control@traderx
+        updated:
+          type: string
+          format: date-time
+    RiskLimitHistory:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        accountId:
+          type: integer
+          format: int32
+        maxOrderNotional:
+          type: number
+        currency:
+          type: string
+        effectiveFrom:
+          type: string
+          format: date-time
+        setBy:
+          type: string
+        changeType:
+          type: string
+          enum: [CREATE, AMEND]
+        changedBy:
+          type: string
+        changedAt:
+          type: string
+          format: date-time
+        reason:
+          type: string
     AccountList:
       type: array
       items:

--- a/account-service/openapi.yaml
+++ b/account-service/openapi.yaml
@@ -176,7 +176,8 @@ paths:
       description: >-
         Sets or amends the risk limit for an account. Used by the risk function, which under
         MiFID II RTS 6 Art. 15 must be independent of the trading desk. Every accepted change
-        appends a row to the limit history.
+        appends a row to the limit history. effectiveFrom may not be in the future - a stored
+        limit is always the limit in force.
       parameters:
         - name: id
           in: path

--- a/account-service/src/main/java/finos/traderx/accountservice/config/RiskLimitProperties.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/config/RiskLimitProperties.java
@@ -1,0 +1,33 @@
+package finos.traderx.accountservice.config;
+
+import finos.traderx.accountservice.model.MissingLimitPolicy;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "traderx.risk-limit")
+public class RiskLimitProperties {
+
+	/** Master switch for the risk limit feature. Off means the service behaves as it did before TRX-102. */
+	private boolean enabled = true;
+
+	/** How callers should treat an account with no limit on file. */
+	private MissingLimitPolicy missingLimitPolicy = MissingLimitPolicy.UNLIMITED;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public MissingLimitPolicy getMissingLimitPolicy() {
+		return this.missingLimitPolicy;
+	}
+
+	public void setMissingLimitPolicy(MissingLimitPolicy missingLimitPolicy) {
+		this.missingLimitPolicy = missingLimitPolicy;
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/controller/RiskLimitController.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/controller/RiskLimitController.java
@@ -1,0 +1,69 @@
+package finos.traderx.accountservice.controller;
+
+import java.util.List;
+
+import finos.traderx.accountservice.exceptions.ResourceNotFoundException;
+import finos.traderx.accountservice.exceptions.RiskLimitsDisabledException;
+import finos.traderx.accountservice.model.RiskLimitHistory;
+import finos.traderx.accountservice.model.RiskLimitRequest;
+import finos.traderx.accountservice.model.RiskLimitView;
+import finos.traderx.accountservice.service.RiskLimitService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin("*")
+@RestController
+@RequestMapping(value = "/account", produces = "application/json")
+public class RiskLimitController {
+
+	@Autowired
+	RiskLimitService riskLimitService;
+
+	/** Read path, called by trade-service on every order submission. */
+	@GetMapping("/{id}/risk-limit")
+	public ResponseEntity<RiskLimitView> getRiskLimit(@PathVariable int id) {
+		return ResponseEntity.ok(this.riskLimitService.getRiskLimit(id));
+	}
+
+	/** Write path, called by the risk function only. */
+	@PutMapping("/{id}/risk-limit")
+	public ResponseEntity<RiskLimitView> setRiskLimit(@PathVariable int id, @RequestBody RiskLimitRequest request) {
+		return ResponseEntity.ok(this.riskLimitService.setRiskLimit(id, request));
+	}
+
+	/** Evidence trail: every value that has been in force, most recent first. */
+	@GetMapping("/{id}/risk-limit/history")
+	public ResponseEntity<List<RiskLimitHistory>> getRiskLimitHistory(@PathVariable int id) {
+		return ResponseEntity.ok(this.riskLimitService.getRiskLimitHistory(id));
+	}
+
+	@ExceptionHandler(ResourceNotFoundException.class)
+	public ResponseEntity<String> resourceNotFoundExceptionMapper(ResourceNotFoundException e) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<String> badRequest(IllegalArgumentException e) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+	}
+
+	@ExceptionHandler(RiskLimitsDisabledException.class)
+	public ResponseEntity<String> disabled(RiskLimitsDisabledException e) {
+		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(e.getMessage());
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<String> generalError(Exception e) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/controller/RiskLimitController.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/controller/RiskLimitController.java
@@ -11,6 +11,7 @@ import finos.traderx.accountservice.service.RiskLimitService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -55,6 +56,12 @@ public class RiskLimitController {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<String> badRequest(IllegalArgumentException e) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+	}
+
+	/** An unparseable body is a bad limit payload, not a service failure. */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<String> unreadableBody(HttpMessageNotReadableException e) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Risk limit payload could not be read: " + e.getMessage());
 	}
 
 	@ExceptionHandler(RiskLimitsDisabledException.class)

--- a/account-service/src/main/java/finos/traderx/accountservice/exceptions/RiskLimitsDisabledException.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/exceptions/RiskLimitsDisabledException.java
@@ -1,0 +1,10 @@
+package finos.traderx.accountservice.exceptions;
+
+public class RiskLimitsDisabledException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public RiskLimitsDisabledException(String message) {
+		super(message);
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/MissingLimitPolicy.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/MissingLimitPolicy.java
@@ -1,0 +1,12 @@
+package finos.traderx.accountservice.model;
+
+/**
+ * What a caller should do when an account has no risk limit on file.
+ *
+ * UNLIMITED - the account is not limit-controlled; the order may proceed.
+ * REJECT    - absence of a limit is itself a reason to reject (fail-closed).
+ */
+public enum MissingLimitPolicy {
+	UNLIMITED,
+	REJECT
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimit.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimit.java
@@ -1,0 +1,88 @@
+package finos.traderx.accountservice.model;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+@Entity
+@Table(name = "RISKLIMITS")
+public class RiskLimit implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "AccountID")
+	private int accountId;
+
+	@Column(name = "MaxOrderNotional", nullable = false, precision = 19, scale = 2)
+	private BigDecimal maxOrderNotional;
+
+	@Column(name = "Currency", length = 3, nullable = false)
+	private String currency;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "EffectiveFrom", nullable = false)
+	private Date effectiveFrom;
+
+	@Column(name = "SetBy", length = 50, nullable = false)
+	private String setBy;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "Updated", nullable = false)
+	private Date updated;
+
+	public int getAccountId() {
+		return this.accountId;
+	}
+
+	public void setAccountId(int accountId) {
+		this.accountId = accountId;
+	}
+
+	public BigDecimal getMaxOrderNotional() {
+		return this.maxOrderNotional;
+	}
+
+	public void setMaxOrderNotional(BigDecimal maxOrderNotional) {
+		this.maxOrderNotional = maxOrderNotional;
+	}
+
+	public String getCurrency() {
+		return this.currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public Date getEffectiveFrom() {
+		return this.effectiveFrom;
+	}
+
+	public void setEffectiveFrom(Date effectiveFrom) {
+		this.effectiveFrom = effectiveFrom;
+	}
+
+	public String getSetBy() {
+		return this.setBy;
+	}
+
+	public void setSetBy(String setBy) {
+		this.setBy = setBy;
+	}
+
+	public Date getUpdated() {
+		return this.updated;
+	}
+
+	public void setUpdated(Date updated) {
+		this.updated = updated;
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitChangeType.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitChangeType.java
@@ -1,0 +1,6 @@
+package finos.traderx.accountservice.model;
+
+public enum RiskLimitChangeType {
+	CREATE,
+	AMEND
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitHistory.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitHistory.java
@@ -1,0 +1,144 @@
+package finos.traderx.accountservice.model;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+/**
+ * Append-only record of a risk limit value that was in force at some point in time.
+ * Rows are inserted, never updated or deleted.
+ */
+@Entity
+@Table(name = "RISKLIMITHISTORY")
+public class RiskLimitHistory implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ID")
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "risk_limit_history_generator")
+	@SequenceGenerator(name = "risk_limit_history_generator", sequenceName = "RISKLIMITHISTORY_SEQ", allocationSize = 1)
+	private long id;
+
+	@Column(name = "AccountID", nullable = false)
+	private int accountId;
+
+	@Column(name = "MaxOrderNotional", nullable = false, precision = 19, scale = 2)
+	private BigDecimal maxOrderNotional;
+
+	@Column(name = "Currency", length = 3, nullable = false)
+	private String currency;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "EffectiveFrom", nullable = false)
+	private Date effectiveFrom;
+
+	@Column(name = "SetBy", length = 50, nullable = false)
+	private String setBy;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "ChangeType", length = 10, nullable = false)
+	private RiskLimitChangeType changeType;
+
+	@Column(name = "ChangedBy", length = 50, nullable = false)
+	private String changedBy;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "ChangedAt", nullable = false)
+	private Date changedAt;
+
+	@Column(name = "Reason", length = 255)
+	private String reason;
+
+	public long getId() {
+		return this.id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public int getAccountId() {
+		return this.accountId;
+	}
+
+	public void setAccountId(int accountId) {
+		this.accountId = accountId;
+	}
+
+	public BigDecimal getMaxOrderNotional() {
+		return this.maxOrderNotional;
+	}
+
+	public void setMaxOrderNotional(BigDecimal maxOrderNotional) {
+		this.maxOrderNotional = maxOrderNotional;
+	}
+
+	public String getCurrency() {
+		return this.currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public Date getEffectiveFrom() {
+		return this.effectiveFrom;
+	}
+
+	public void setEffectiveFrom(Date effectiveFrom) {
+		this.effectiveFrom = effectiveFrom;
+	}
+
+	public String getSetBy() {
+		return this.setBy;
+	}
+
+	public void setSetBy(String setBy) {
+		this.setBy = setBy;
+	}
+
+	public RiskLimitChangeType getChangeType() {
+		return this.changeType;
+	}
+
+	public void setChangeType(RiskLimitChangeType changeType) {
+		this.changeType = changeType;
+	}
+
+	public String getChangedBy() {
+		return this.changedBy;
+	}
+
+	public void setChangedBy(String changedBy) {
+		this.changedBy = changedBy;
+	}
+
+	public Date getChangedAt() {
+		return this.changedAt;
+	}
+
+	public void setChangedAt(Date changedAt) {
+		this.changedAt = changedAt;
+	}
+
+	public String getReason() {
+		return this.reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitRequest.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitRequest.java
@@ -1,0 +1,56 @@
+package finos.traderx.accountservice.model;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Payload for PUT /account/{id}/risk-limit. Sent by the risk function, not by the desk.
+ */
+public class RiskLimitRequest {
+
+	private BigDecimal maxOrderNotional;
+	private String currency;
+	private Date effectiveFrom;
+	private String setBy;
+	private String reason;
+
+	public BigDecimal getMaxOrderNotional() {
+		return this.maxOrderNotional;
+	}
+
+	public void setMaxOrderNotional(BigDecimal maxOrderNotional) {
+		this.maxOrderNotional = maxOrderNotional;
+	}
+
+	public String getCurrency() {
+		return this.currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public Date getEffectiveFrom() {
+		return this.effectiveFrom;
+	}
+
+	public void setEffectiveFrom(Date effectiveFrom) {
+		this.effectiveFrom = effectiveFrom;
+	}
+
+	public String getSetBy() {
+		return this.setBy;
+	}
+
+	public void setSetBy(String setBy) {
+		this.setBy = setBy;
+	}
+
+	public String getReason() {
+		return this.reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitView.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/RiskLimitView.java
@@ -1,0 +1,77 @@
+package finos.traderx.accountservice.model;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Response for GET /account/{id}/risk-limit.
+ *
+ * The response is always 200 for a known account. Callers must branch on limitPresent
+ * rather than on the HTTP status, and when no limit is present they must honour
+ * missingLimitPolicy - which is a configuration decision owned by compliance, not by
+ * whichever service happens to be doing the enforcing.
+ */
+public class RiskLimitView {
+
+	private int accountId;
+	private boolean limitPresent;
+	private MissingLimitPolicy missingLimitPolicy;
+	private BigDecimal maxOrderNotional;
+	private String currency;
+	private Date effectiveFrom;
+	private String setBy;
+	private Date updated;
+
+	public static RiskLimitView of(RiskLimit limit, MissingLimitPolicy missingLimitPolicy) {
+		RiskLimitView view = new RiskLimitView();
+		view.accountId = limit.getAccountId();
+		view.limitPresent = true;
+		view.missingLimitPolicy = missingLimitPolicy;
+		view.maxOrderNotional = limit.getMaxOrderNotional();
+		view.currency = limit.getCurrency();
+		view.effectiveFrom = limit.getEffectiveFrom();
+		view.setBy = limit.getSetBy();
+		view.updated = limit.getUpdated();
+		return view;
+	}
+
+	public static RiskLimitView absent(int accountId, MissingLimitPolicy missingLimitPolicy) {
+		RiskLimitView view = new RiskLimitView();
+		view.accountId = accountId;
+		view.limitPresent = false;
+		view.missingLimitPolicy = missingLimitPolicy;
+		return view;
+	}
+
+	public int getAccountId() {
+		return this.accountId;
+	}
+
+	public boolean isLimitPresent() {
+		return this.limitPresent;
+	}
+
+	public MissingLimitPolicy getMissingLimitPolicy() {
+		return this.missingLimitPolicy;
+	}
+
+	public BigDecimal getMaxOrderNotional() {
+		return this.maxOrderNotional;
+	}
+
+	public String getCurrency() {
+		return this.currency;
+	}
+
+	public Date getEffectiveFrom() {
+		return this.effectiveFrom;
+	}
+
+	public String getSetBy() {
+		return this.setBy;
+	}
+
+	public Date getUpdated() {
+		return this.updated;
+	}
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/repository/RiskLimitHistoryRepository.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/repository/RiskLimitHistoryRepository.java
@@ -1,0 +1,12 @@
+package finos.traderx.accountservice.repository;
+
+import java.util.List;
+
+import finos.traderx.accountservice.model.RiskLimitHistory;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface RiskLimitHistoryRepository extends CrudRepository<RiskLimitHistory, Long> {
+
+	List<RiskLimitHistory> findByAccountIdOrderByChangedAtDescIdDesc(int accountId);
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/repository/RiskLimitRepository.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/repository/RiskLimitRepository.java
@@ -1,0 +1,8 @@
+package finos.traderx.accountservice.repository;
+
+import finos.traderx.accountservice.model.RiskLimit;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface RiskLimitRepository extends CrudRepository<RiskLimit, Integer> {
+}

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -1,8 +1,10 @@
 package finos.traderx.accountservice.service;
 
 import java.math.BigDecimal;
+import java.util.Currency;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import finos.traderx.accountservice.config.RiskLimitProperties;
@@ -59,12 +61,18 @@ public class RiskLimitService {
 
 	public List<RiskLimitHistory> getRiskLimitHistory(int accountId) {
 		this.accountService.getAccountById(accountId);
+
+		if (!this.riskLimitProperties.isEnabled()) {
+			return List.of();
+		}
+
 		return this.riskLimitHistoryRepository.findByAccountIdOrderByChangedAtDescIdDesc(accountId);
 	}
 
 	/**
 	 * Sets or amends the limit for an account. Every accepted change appends a history row
-	 * before the current value is replaced, so the value in force at any past point in time
+	 * holding the newly effective value together with who changed it and why; the superseded
+	 * value survives as the preceding row, so the limit in force at any past point in time
 	 * remains reconstructible.
 	 */
 	@Transactional
@@ -83,7 +91,7 @@ public class RiskLimitService {
 		RiskLimit limit = existing.orElseGet(RiskLimit::new);
 		limit.setAccountId(accountId);
 		limit.setMaxOrderNotional(request.getMaxOrderNotional());
-		limit.setCurrency(request.getCurrency().toUpperCase());
+		limit.setCurrency(request.getCurrency().toUpperCase(Locale.ROOT));
 		limit.setEffectiveFrom(request.getEffectiveFrom() == null ? now : request.getEffectiveFrom());
 		limit.setSetBy(request.getSetBy());
 		limit.setUpdated(now);
@@ -115,11 +123,23 @@ public class RiskLimitService {
 		if (request.getMaxOrderNotional() == null || request.getMaxOrderNotional().compareTo(BigDecimal.ZERO) < 0) {
 			throw new IllegalArgumentException("maxOrderNotional must be present and not negative");
 		}
-		if (request.getCurrency() == null || request.getCurrency().length() != 3) {
+		if (request.getCurrency() == null || !isIsoCurrency(request.getCurrency())) {
 			throw new IllegalArgumentException("currency must be a 3 letter ISO 4217 code");
 		}
 		if (request.getSetBy() == null || request.getSetBy().isBlank()) {
 			throw new IllegalArgumentException("setBy must identify who set the limit");
+		}
+		if (request.getEffectiveFrom() != null && request.getEffectiveFrom().after(new Date())) {
+			throw new IllegalArgumentException("effectiveFrom cannot be in the future; a stored limit is always the limit in force");
+		}
+	}
+
+	private boolean isIsoCurrency(String code) {
+		try {
+			Currency.getInstance(code.toUpperCase(Locale.ROOT));
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
 		}
 	}
 }

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -90,7 +90,7 @@ public class RiskLimitService {
 
 		RiskLimit limit = existing.orElseGet(RiskLimit::new);
 		limit.setAccountId(accountId);
-		limit.setMaxOrderNotional(request.getMaxOrderNotional());
+		limit.setMaxOrderNotional(request.getMaxOrderNotional().stripTrailingZeros().setScale(2));
 		limit.setCurrency(request.getCurrency().toUpperCase(Locale.ROOT));
 		limit.setEffectiveFrom(request.getEffectiveFrom() == null ? now : request.getEffectiveFrom());
 		limit.setSetBy(request.getSetBy());
@@ -123,11 +123,18 @@ public class RiskLimitService {
 		if (request.getMaxOrderNotional() == null || request.getMaxOrderNotional().compareTo(BigDecimal.ZERO) < 0) {
 			throw new IllegalArgumentException("maxOrderNotional must be present and not negative");
 		}
+		if (request.getMaxOrderNotional().stripTrailingZeros().scale() > 2
+				|| request.getMaxOrderNotional().precision() - request.getMaxOrderNotional().scale() > 17) {
+			throw new IllegalArgumentException("maxOrderNotional must fit DECIMAL(19,2); it is stored and enforced to 2 decimal places");
+		}
 		if (request.getCurrency() == null || !isIsoCurrency(request.getCurrency())) {
 			throw new IllegalArgumentException("currency must be a 3 letter ISO 4217 code");
 		}
-		if (request.getSetBy() == null || request.getSetBy().isBlank()) {
-			throw new IllegalArgumentException("setBy must identify who set the limit");
+		if (request.getSetBy() == null || request.getSetBy().isBlank() || request.getSetBy().length() > 50) {
+			throw new IllegalArgumentException("setBy must identify who set the limit and be at most 50 characters");
+		}
+		if (request.getReason() != null && request.getReason().length() > 255) {
+			throw new IllegalArgumentException("reason must be at most 255 characters");
 		}
 		if (request.getEffectiveFrom() != null && request.getEffectiveFrom().after(new Date())) {
 			throw new IllegalArgumentException("effectiveFrom cannot be in the future; a stored limit is always the limit in force");

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -19,6 +19,10 @@ import finos.traderx.accountservice.model.RiskLimitView;
 import finos.traderx.accountservice.repository.RiskLimitHistoryRepository;
 import finos.traderx.accountservice.repository.RiskLimitRepository;
 
+import jakarta.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 public class RiskLimitService {
+
+	private static final Logger log = LoggerFactory.getLogger(RiskLimitService.class);
 
 	/** Absorbs client clock drift so a caller stamping "now" is not rejected as future-dated. */
 	private static final long CLOCK_SKEW_TOLERANCE_MS = 60_000L;
@@ -45,6 +51,19 @@ public class RiskLimitService {
 
 	@Autowired
 	RiskLimitProperties riskLimitProperties;
+
+	/**
+	 * The kill switch is fail-open by construction: with limits off the service behaves as it did
+	 * before TRX-102. That deliberately overrides a configured REJECT, so say so loudly at startup.
+	 */
+	@PostConstruct
+	void warnIfKillSwitchOverridesRejectPolicy() {
+		if (!this.riskLimitProperties.isEnabled()
+				&& this.riskLimitProperties.getMissingLimitPolicy() == MissingLimitPolicy.REJECT) {
+			log.warn("traderx.risk-limit.enabled=false overrides missing-limit-policy=REJECT: "
+					+ "every account is now reported as UNLIMITED and no limit can be administered");
+		}
+	}
 
 	/**
 	 * Reads the limit in force for an account. Throws if the account itself is unknown;
@@ -129,10 +148,10 @@ public class RiskLimitService {
 		}
 		try {
 			if (storedNotional(request.getMaxOrderNotional()).precision() > 19) {
-				throw new ArithmeticException("too many digits");
+				throw new IllegalArgumentException("maxOrderNotional must fit DECIMAL(19,2); it is limited to 17 digits before the decimal point");
 			}
 		} catch (ArithmeticException e) {
-			throw new IllegalArgumentException("maxOrderNotional must fit DECIMAL(19,2); it is stored and enforced to 2 decimal places");
+			throw new IllegalArgumentException("maxOrderNotional is stored and enforced to 2 decimal places");
 		}
 		if (request.getCurrency() == null || !isIsoCurrency(request.getCurrency())) {
 			throw new IllegalArgumentException("currency must be a 3 letter ISO 4217 code");

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -1,6 +1,7 @@
 package finos.traderx.accountservice.service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
@@ -90,7 +91,7 @@ public class RiskLimitService {
 
 		RiskLimit limit = existing.orElseGet(RiskLimit::new);
 		limit.setAccountId(accountId);
-		limit.setMaxOrderNotional(request.getMaxOrderNotional().stripTrailingZeros().setScale(2));
+		limit.setMaxOrderNotional(request.getMaxOrderNotional().stripTrailingZeros().setScale(2, RoundingMode.UNNECESSARY));
 		limit.setCurrency(request.getCurrency().toUpperCase(Locale.ROOT));
 		limit.setEffectiveFrom(request.getEffectiveFrom() == null ? now : request.getEffectiveFrom());
 		limit.setSetBy(request.getSetBy());

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -91,7 +91,7 @@ public class RiskLimitService {
 
 		RiskLimit limit = existing.orElseGet(RiskLimit::new);
 		limit.setAccountId(accountId);
-		limit.setMaxOrderNotional(request.getMaxOrderNotional().stripTrailingZeros().setScale(2, RoundingMode.UNNECESSARY));
+		limit.setMaxOrderNotional(storedNotional(request.getMaxOrderNotional()));
 		limit.setCurrency(request.getCurrency().toUpperCase(Locale.ROOT));
 		limit.setEffectiveFrom(request.getEffectiveFrom() == null ? now : request.getEffectiveFrom());
 		limit.setSetBy(request.getSetBy());
@@ -124,8 +124,11 @@ public class RiskLimitService {
 		if (request.getMaxOrderNotional() == null || request.getMaxOrderNotional().compareTo(BigDecimal.ZERO) < 0) {
 			throw new IllegalArgumentException("maxOrderNotional must be present and not negative");
 		}
-		if (request.getMaxOrderNotional().stripTrailingZeros().scale() > 2
-				|| request.getMaxOrderNotional().precision() - request.getMaxOrderNotional().scale() > 17) {
+		try {
+			if (storedNotional(request.getMaxOrderNotional()).precision() > 19) {
+				throw new ArithmeticException("too many digits");
+			}
+		} catch (ArithmeticException e) {
 			throw new IllegalArgumentException("maxOrderNotional must fit DECIMAL(19,2); it is stored and enforced to 2 decimal places");
 		}
 		if (request.getCurrency() == null || !isIsoCurrency(request.getCurrency())) {
@@ -140,6 +143,11 @@ public class RiskLimitService {
 		if (request.getEffectiveFrom() != null && request.getEffectiveFrom().after(new Date())) {
 			throw new IllegalArgumentException("effectiveFrom cannot be in the future; a stored limit is always the limit in force");
 		}
+	}
+
+	/** The exact value the RiskLimits.MaxOrderNotional column holds, so validation and storage cannot drift. */
+	private BigDecimal storedNotional(BigDecimal requested) {
+		return requested.stripTrailingZeros().setScale(2, RoundingMode.UNNECESSARY);
 	}
 
 	private boolean isIsoCurrency(String code) {

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -31,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class RiskLimitService {
 
+	/** Absorbs client clock drift so a caller stamping "now" is not rejected as future-dated. */
+	private static final long CLOCK_SKEW_TOLERANCE_MS = 60_000L;
+
 	@Autowired
 	RiskLimitRepository riskLimitRepository;
 
@@ -140,7 +143,8 @@ public class RiskLimitService {
 		if (request.getReason() != null && request.getReason().length() > 255) {
 			throw new IllegalArgumentException("reason must be at most 255 characters");
 		}
-		if (request.getEffectiveFrom() != null && request.getEffectiveFrom().after(new Date())) {
+		if (request.getEffectiveFrom() != null
+				&& request.getEffectiveFrom().getTime() > System.currentTimeMillis() + CLOCK_SKEW_TOLERANCE_MS) {
 			throw new IllegalArgumentException("effectiveFrom cannot be in the future; a stored limit is always the limit in force");
 		}
 	}

--- a/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/service/RiskLimitService.java
@@ -1,0 +1,125 @@
+package finos.traderx.accountservice.service;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import finos.traderx.accountservice.config.RiskLimitProperties;
+import finos.traderx.accountservice.exceptions.RiskLimitsDisabledException;
+import finos.traderx.accountservice.model.MissingLimitPolicy;
+import finos.traderx.accountservice.model.RiskLimit;
+import finos.traderx.accountservice.model.RiskLimitChangeType;
+import finos.traderx.accountservice.model.RiskLimitHistory;
+import finos.traderx.accountservice.model.RiskLimitRequest;
+import finos.traderx.accountservice.model.RiskLimitView;
+import finos.traderx.accountservice.repository.RiskLimitHistoryRepository;
+import finos.traderx.accountservice.repository.RiskLimitRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns pre-trade risk limits. account-service is the authority that sets them; trade-service
+ * only reads them at enforcement time, which is what keeps limit-setting independent of the
+ * desk that trades against them (MiFID II RTS 6 Art. 15).
+ */
+@Service
+public class RiskLimitService {
+
+	@Autowired
+	RiskLimitRepository riskLimitRepository;
+
+	@Autowired
+	RiskLimitHistoryRepository riskLimitHistoryRepository;
+
+	@Autowired
+	AccountService accountService;
+
+	@Autowired
+	RiskLimitProperties riskLimitProperties;
+
+	/**
+	 * Reads the limit in force for an account. Throws if the account itself is unknown;
+	 * an account that exists but has no limit is a valid state, described by the returned view.
+	 */
+	public RiskLimitView getRiskLimit(int accountId) {
+		this.accountService.getAccountById(accountId);
+
+		if (!this.riskLimitProperties.isEnabled()) {
+			return RiskLimitView.absent(accountId, MissingLimitPolicy.UNLIMITED);
+		}
+
+		Optional<RiskLimit> limit = this.riskLimitRepository.findById(accountId);
+		return limit
+				.map(l -> RiskLimitView.of(l, this.riskLimitProperties.getMissingLimitPolicy()))
+				.orElseGet(() -> RiskLimitView.absent(accountId, this.riskLimitProperties.getMissingLimitPolicy()));
+	}
+
+	public List<RiskLimitHistory> getRiskLimitHistory(int accountId) {
+		this.accountService.getAccountById(accountId);
+		return this.riskLimitHistoryRepository.findByAccountIdOrderByChangedAtDescIdDesc(accountId);
+	}
+
+	/**
+	 * Sets or amends the limit for an account. Every accepted change appends a history row
+	 * before the current value is replaced, so the value in force at any past point in time
+	 * remains reconstructible.
+	 */
+	@Transactional
+	public RiskLimitView setRiskLimit(int accountId, RiskLimitRequest request) {
+		if (!this.riskLimitProperties.isEnabled()) {
+			throw new RiskLimitsDisabledException("Risk limit administration is disabled (traderx.risk-limit.enabled=false)");
+		}
+
+		this.accountService.getAccountById(accountId);
+		validate(request);
+
+		Date now = new Date();
+		Optional<RiskLimit> existing = this.riskLimitRepository.findById(accountId);
+		RiskLimitChangeType changeType = existing.isPresent() ? RiskLimitChangeType.AMEND : RiskLimitChangeType.CREATE;
+
+		RiskLimit limit = existing.orElseGet(RiskLimit::new);
+		limit.setAccountId(accountId);
+		limit.setMaxOrderNotional(request.getMaxOrderNotional());
+		limit.setCurrency(request.getCurrency().toUpperCase());
+		limit.setEffectiveFrom(request.getEffectiveFrom() == null ? now : request.getEffectiveFrom());
+		limit.setSetBy(request.getSetBy());
+		limit.setUpdated(now);
+
+		RiskLimit saved = this.riskLimitRepository.save(limit);
+		this.riskLimitHistoryRepository.save(historyOf(saved, changeType, now, request.getReason()));
+
+		return RiskLimitView.of(saved, this.riskLimitProperties.getMissingLimitPolicy());
+	}
+
+	private RiskLimitHistory historyOf(RiskLimit limit, RiskLimitChangeType changeType, Date changedAt, String reason) {
+		RiskLimitHistory history = new RiskLimitHistory();
+		history.setAccountId(limit.getAccountId());
+		history.setMaxOrderNotional(limit.getMaxOrderNotional());
+		history.setCurrency(limit.getCurrency());
+		history.setEffectiveFrom(limit.getEffectiveFrom());
+		history.setSetBy(limit.getSetBy());
+		history.setChangeType(changeType);
+		history.setChangedBy(limit.getSetBy());
+		history.setChangedAt(changedAt);
+		history.setReason(reason);
+		return history;
+	}
+
+	private void validate(RiskLimitRequest request) {
+		if (request == null) {
+			throw new IllegalArgumentException("Risk limit payload is required");
+		}
+		if (request.getMaxOrderNotional() == null || request.getMaxOrderNotional().compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("maxOrderNotional must be present and not negative");
+		}
+		if (request.getCurrency() == null || request.getCurrency().length() != 3) {
+			throw new IllegalArgumentException("currency must be a 3 letter ISO 4217 code");
+		}
+		if (request.getSetBy() == null || request.getSetBy().isBlank()) {
+			throw new IllegalArgumentException("setBy must identify who set the limit");
+		}
+	}
+}

--- a/account-service/src/main/resources/application.properties
+++ b/account-service/src/main/resources/application.properties
@@ -13,3 +13,9 @@ spring.threads.virtual.enabled=true
 server.max-http-request-header-size=1000000
 
 people.service.url=${PEOPLE_SERVICE_URL:http://${PEOPLE_SERVICE_HOST:localhost}:18089}
+
+# TRX-102 pre-trade risk limits. Off returns the service to its pre-TRX-102 behaviour:
+# no limit is ever reported and the admin endpoint refuses writes.
+traderx.risk-limit.enabled=${RISK_LIMIT_ENABLED:true}
+# UNLIMITED or REJECT - how callers must treat an account with no limit on file.
+traderx.risk-limit.missing-limit-policy=${RISK_LIMIT_MISSING_POLICY:UNLIMITED}

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitDisabledTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitDisabledTests.java
@@ -3,6 +3,7 @@ package finos.traderx.accountservice;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 
@@ -23,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
  * With the feature switched off the service must look exactly as it did before TRX-102:
  * no limit is ever reported, and nothing can be written.
  */
-@SpringBootTest(properties = "traderx.risk-limit.enabled=false")
+@SpringBootTest(properties = { "traderx.risk-limit.enabled=false", "spring.datasource.url=jdbc:h2:mem:test-flag-off" })
 @TestPropertySource(locations = "/test-application.properties")
 class RiskLimitDisabledTests {
 
@@ -42,6 +43,7 @@ class RiskLimitDisabledTests {
         RiskLimitView view = riskLimitService.getRiskLimit(accountId);
         assertFalse(view.isLimitPresent());
         assertEquals(MissingLimitPolicy.UNLIMITED, view.getMissingLimitPolicy());
+        assertTrue(riskLimitService.getRiskLimitHistory(accountId).isEmpty());
 
         RiskLimitRequest request = new RiskLimitRequest();
         request.setMaxOrderNotional(new BigDecimal("1000.00"));

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitDisabledTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitDisabledTests.java
@@ -1,0 +1,52 @@
+package finos.traderx.accountservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+
+import finos.traderx.accountservice.exceptions.RiskLimitsDisabledException;
+import finos.traderx.accountservice.model.Account;
+import finos.traderx.accountservice.model.MissingLimitPolicy;
+import finos.traderx.accountservice.model.RiskLimitRequest;
+import finos.traderx.accountservice.model.RiskLimitView;
+import finos.traderx.accountservice.service.AccountService;
+import finos.traderx.accountservice.service.RiskLimitService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * With the feature switched off the service must look exactly as it did before TRX-102:
+ * no limit is ever reported, and nothing can be written.
+ */
+@SpringBootTest(properties = "traderx.risk-limit.enabled=false")
+@TestPropertySource(locations = "/test-application.properties")
+class RiskLimitDisabledTests {
+
+    @Autowired
+    AccountService accountService;
+
+    @Autowired
+    RiskLimitService riskLimitService;
+
+    @Test
+    void featureFlagOffMeansNoLimitsAndNoWrites() {
+        Account account = new Account();
+        account.setDisplayName("flag off account");
+        int accountId = accountService.upsertAccount(account).getId();
+
+        RiskLimitView view = riskLimitService.getRiskLimit(accountId);
+        assertFalse(view.isLimitPresent());
+        assertEquals(MissingLimitPolicy.UNLIMITED, view.getMissingLimitPolicy());
+
+        RiskLimitRequest request = new RiskLimitRequest();
+        request.setMaxOrderNotional(new BigDecimal("1000.00"));
+        request.setCurrency("USD");
+        request.setSetBy("risk.control@traderx");
+        assertThrows(RiskLimitsDisabledException.class, () -> riskLimitService.setRiskLimit(accountId, request));
+    }
+}

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:test-risk-limits")
 @TestPropertySource(locations = "/test-application.properties")
 class RiskLimitServiceTests {
 

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
@@ -119,6 +119,12 @@ class RiskLimitServiceTests {
         badCurrency.setCurrency("DOLLARS");
         assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, badCurrency));
 
+        RiskLimitRequest tooPrecise = request("100.999", "risk.control@traderx", null);
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, tooPrecise));
+
+        RiskLimitRequest longOwner = request("1000.00", "x".repeat(51), null);
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, longOwner));
+
         RiskLimitRequest notACurrency = request("1000.00", "risk.control@traderx", null);
         notACurrency.setCurrency("XQZ");
         assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, notACurrency));

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
@@ -1,0 +1,123 @@
+package finos.traderx.accountservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import finos.traderx.accountservice.exceptions.ResourceNotFoundException;
+import finos.traderx.accountservice.model.Account;
+import finos.traderx.accountservice.model.MissingLimitPolicy;
+import finos.traderx.accountservice.model.RiskLimitChangeType;
+import finos.traderx.accountservice.model.RiskLimitHistory;
+import finos.traderx.accountservice.model.RiskLimitRequest;
+import finos.traderx.accountservice.model.RiskLimitView;
+import finos.traderx.accountservice.service.AccountService;
+import finos.traderx.accountservice.service.RiskLimitService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(locations = "/test-application.properties")
+class RiskLimitServiceTests {
+
+    @Autowired
+    AccountService accountService;
+
+    @Autowired
+    RiskLimitService riskLimitService;
+
+    private int newAccount(String displayName) {
+        Account account = new Account();
+        account.setDisplayName(displayName);
+        return accountService.upsertAccount(account).getId();
+    }
+
+    private RiskLimitRequest request(String notional, String setBy, String reason) {
+        RiskLimitRequest request = new RiskLimitRequest();
+        request.setMaxOrderNotional(new BigDecimal(notional));
+        request.setCurrency("usd");
+        request.setSetBy(setBy);
+        request.setReason(reason);
+        return request;
+    }
+
+    @Test
+    void putThenGetReturnsTheLimitInForce() {
+        int accountId = newAccount("limit account");
+
+        riskLimitService.setRiskLimit(accountId, request("50000.00", "risk.control@traderx", "Initial limit"));
+
+        RiskLimitView view = riskLimitService.getRiskLimit(accountId);
+        assertTrue(view.isLimitPresent());
+        assertEquals(0, new BigDecimal("50000.00").compareTo(view.getMaxOrderNotional()));
+        assertEquals("USD", view.getCurrency());
+        assertEquals("risk.control@traderx", view.getSetBy());
+    }
+
+    @Test
+    void amendingALimitLeavesATrailOfThePreviousValue() {
+        int accountId = newAccount("amend account");
+
+        riskLimitService.setRiskLimit(accountId, request("50000.00", "risk.control@traderx", "Initial limit"));
+        riskLimitService.setRiskLimit(accountId, request("75000.00", "head.of.risk@traderx", "Client uplift approved"));
+
+        assertEquals(0, new BigDecimal("75000.00").compareTo(riskLimitService.getRiskLimit(accountId).getMaxOrderNotional()));
+
+        List<RiskLimitHistory> history = riskLimitService.getRiskLimitHistory(accountId);
+        assertEquals(2, history.size());
+
+        RiskLimitHistory latest = history.get(0);
+        assertEquals(RiskLimitChangeType.AMEND, latest.getChangeType());
+        assertEquals("head.of.risk@traderx", latest.getChangedBy());
+        assertEquals("Client uplift approved", latest.getReason());
+        assertEquals(0, new BigDecimal("75000.00").compareTo(latest.getMaxOrderNotional()));
+
+        RiskLimitHistory superseded = history.get(1);
+        assertEquals(RiskLimitChangeType.CREATE, superseded.getChangeType());
+        assertEquals("risk.control@traderx", superseded.getChangedBy());
+        assertEquals(0, new BigDecimal("50000.00").compareTo(superseded.getMaxOrderNotional()));
+    }
+
+    @Test
+    void accountWithNoLimitReportsTheConfiguredMissingLimitPolicy() {
+        int accountId = newAccount("unlimited account");
+
+        RiskLimitView view = riskLimitService.getRiskLimit(accountId);
+        assertFalse(view.isLimitPresent());
+        assertEquals(MissingLimitPolicy.UNLIMITED, view.getMissingLimitPolicy());
+        assertNull(view.getMaxOrderNotional());
+        assertTrue(riskLimitService.getRiskLimitHistory(accountId).isEmpty());
+    }
+
+    @Test
+    void unknownAccountIsNotFound() {
+        assertThrows(ResourceNotFoundException.class, () -> riskLimitService.getRiskLimit(-1));
+        assertThrows(ResourceNotFoundException.class,
+                () -> riskLimitService.setRiskLimit(-1, request("1000.00", "risk.control@traderx", null)));
+    }
+
+    @Test
+    void invalidPayloadIsRejected() {
+        int accountId = newAccount("validation account");
+
+        RiskLimitRequest negative = request("-1.00", "risk.control@traderx", null);
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, negative));
+
+        RiskLimitRequest noOwner = request("1000.00", "  ", null);
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, noOwner));
+
+        RiskLimitRequest badCurrency = request("1000.00", "risk.control@traderx", null);
+        badCurrency.setCurrency("DOLLARS");
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, badCurrency));
+
+        assertFalse(riskLimitService.getRiskLimit(accountId).isLimitPresent());
+    }
+}

--- a/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
+++ b/account-service/src/test/java/finos/traderx/accountservice/RiskLimitServiceTests.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
 
 import finos.traderx.accountservice.exceptions.ResourceNotFoundException;
@@ -117,6 +118,14 @@ class RiskLimitServiceTests {
         RiskLimitRequest badCurrency = request("1000.00", "risk.control@traderx", null);
         badCurrency.setCurrency("DOLLARS");
         assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, badCurrency));
+
+        RiskLimitRequest notACurrency = request("1000.00", "risk.control@traderx", null);
+        notACurrency.setCurrency("XQZ");
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, notACurrency));
+
+        RiskLimitRequest futureDated = request("1000.00", "risk.control@traderx", null);
+        futureDated.setEffectiveFrom(new Date(System.currentTimeMillis() + 86400000L));
+        assertThrows(IllegalArgumentException.class, () -> riskLimitService.setRiskLimit(accountId, futureDated));
 
         assertFalse(riskLimitService.getRiskLimit(accountId).isLimitPresent());
     }

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -38,9 +38,9 @@ CREATE TABLE RiskLimits ( AccountID INTEGER PRIMARY KEY, MaxOrderNotional DECIMA
 
 Alter Table RiskLimits Add Foreign Key (AccountID) references Accounts(ID);
 
---- Append-only trail of every limit value that has ever been in force. Rows are never
---- updated or deleted; an amendment writes the superseded value here before RiskLimits
---- is overwritten.
+--- Append-only trail of every limit value that has ever been in force. Each change appends
+--- one row holding the newly effective value plus who changed it and why; the superseded
+--- value survives as the preceding row. Rows are never updated or deleted.
 
 CREATE TABLE RiskLimitHistory ( ID BIGINT PRIMARY KEY, AccountID INTEGER NOT NULL, MaxOrderNotional DECIMAL(19,2) NOT NULL, Currency VARCHAR(3) NOT NULL, EffectiveFrom TIMESTAMP NOT NULL, SetBy VARCHAR(50) NOT NULL, ChangeType VARCHAR(10) NOT NULL check (ChangeType in ('CREATE','AMEND')), ChangedBy VARCHAR(50) NOT NULL, ChangedAt TIMESTAMP NOT NULL, Reason VARCHAR(255) );
 

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -46,6 +46,8 @@ CREATE TABLE RiskLimitHistory ( ID BIGINT PRIMARY KEY, AccountID INTEGER NOT NUL
 
 Alter Table RiskLimitHistory Add Foreign Key (AccountID) references Accounts(ID);
 
+CREATE INDEX IDX_RISKLIMITHISTORY_ACCOUNT ON RiskLimitHistory (AccountID, ChangedAt);
+
 CREATE SEQUENCE RISKLIMITHISTORY_SEQ start with 1000 INCREMENT BY 1;
 
 --- SAMPLE DATA ---

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -1,3 +1,9 @@
+Drop Table RiskLimitHistory IF EXISTS;
+
+Drop Table RiskLimits IF EXISTS;
+
+Drop Sequence RISKLIMITHISTORY_SEQ IF EXISTS;
+
 Drop Table Trades IF EXISTS;
 
 Drop Table AccountUsers IF EXISTS; 
@@ -23,6 +29,24 @@ CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TI
 Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID); 
 
 CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
+
+--- TRX-102: pre-trade risk limits. Set by the risk function, read by trade-service at
+--- enforcement time. MiFID II RTS 6 Art. 15 requires the limit to be owned by a function
+--- independent of the desk, so the limit lives here and never in trade-service.
+
+CREATE TABLE RiskLimits ( AccountID INTEGER PRIMARY KEY, MaxOrderNotional DECIMAL(19,2) NOT NULL check MaxOrderNotional >= 0, Currency VARCHAR(3) NOT NULL, EffectiveFrom TIMESTAMP NOT NULL, SetBy VARCHAR(50) NOT NULL, Updated TIMESTAMP NOT NULL );
+
+Alter Table RiskLimits Add Foreign Key (AccountID) references Accounts(ID);
+
+--- Append-only trail of every limit value that has ever been in force. Rows are never
+--- updated or deleted; an amendment writes the superseded value here before RiskLimits
+--- is overwritten.
+
+CREATE TABLE RiskLimitHistory ( ID BIGINT PRIMARY KEY, AccountID INTEGER NOT NULL, MaxOrderNotional DECIMAL(19,2) NOT NULL, Currency VARCHAR(3) NOT NULL, EffectiveFrom TIMESTAMP NOT NULL, SetBy VARCHAR(50) NOT NULL, ChangeType VARCHAR(10) NOT NULL check (ChangeType in ('CREATE','AMEND')), ChangedBy VARCHAR(50) NOT NULL, ChangedAt TIMESTAMP NOT NULL, Reason VARCHAR(255) );
+
+Alter Table RiskLimitHistory Add Foreign Key (AccountID) references Accounts(ID);
+
+CREATE SEQUENCE RISKLIMITHISTORY_SEQ start with 1000 INCREMENT BY 1;
 
 --- SAMPLE DATA ---
 
@@ -68,3 +92,21 @@ INSERT into Positions (AccountID, Security, Updated, Quantity) VALUES(22214, 'C'
 
 INSERT into Trades(ID, Created, Updated, Security, Side, Quantity, State, AccountID) VALUES('TRADE-52355-AABBCC', NOW(), NOW(), 'BAC', 'Sell', 2400, 'Settled', 52355); 
 INSERT into Positions (AccountID, Security, Updated, Quantity) VALUES(52355, 'BAC',NOW(), -2400); 
+
+--- TRX-102 seed limits. 11413 is deliberately tight: a 1,000 share order in a ~USD 100
+--- name breaches it, so the enforcement path (TRX-101) can be demonstrated live.
+
+INSERT into RiskLimits (AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, Updated) VALUES (11413, 50000.00, 'USD', NOW(), 'risk.control@traderx', NOW());
+INSERT into RiskLimits (AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, Updated) VALUES (22214, 2500000.00, 'USD', NOW(), 'risk.control@traderx', NOW());
+INSERT into RiskLimits (AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, Updated) VALUES (42422, 5000000.00, 'USD', NOW(), 'risk.control@traderx', NOW());
+INSERT into RiskLimits (AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, Updated) VALUES (52355, 10000000.00, 'USD', NOW(), 'risk.control@traderx', NOW());
+INSERT into RiskLimits (AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, Updated) VALUES (62654, 7500000.00, 'USD', NOW(), 'risk.control@traderx', NOW());
+
+--- Accounts 10031 (Internal Trading Book) and 44044 (Trading Account 1) are left without a
+--- limit on purpose, so the missing-limit behaviour is visible in the demo.
+
+INSERT into RiskLimitHistory (ID, AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, ChangeType, ChangedBy, ChangedAt, Reason) VALUES (1, 11413, 50000.00, 'USD', NOW(), 'risk.control@traderx', 'CREATE', 'risk.control@traderx', NOW(), 'Initial limit set by risk control');
+INSERT into RiskLimitHistory (ID, AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, ChangeType, ChangedBy, ChangedAt, Reason) VALUES (2, 22214, 2500000.00, 'USD', NOW(), 'risk.control@traderx', 'CREATE', 'risk.control@traderx', NOW(), 'Initial limit set by risk control');
+INSERT into RiskLimitHistory (ID, AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, ChangeType, ChangedBy, ChangedAt, Reason) VALUES (3, 42422, 5000000.00, 'USD', NOW(), 'risk.control@traderx', 'CREATE', 'risk.control@traderx', NOW(), 'Initial limit set by risk control');
+INSERT into RiskLimitHistory (ID, AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, ChangeType, ChangedBy, ChangedAt, Reason) VALUES (4, 52355, 10000000.00, 'USD', NOW(), 'risk.control@traderx', 'CREATE', 'risk.control@traderx', NOW(), 'Initial limit set by risk control');
+INSERT into RiskLimitHistory (ID, AccountID, MaxOrderNotional, Currency, EffectiveFrom, SetBy, ChangeType, ChangedBy, ChangedAt, Reason) VALUES (5, 62654, 7500000.00, 'USD', NOW(), 'risk.control@traderx', 'CREATE', 'risk.control@traderx', NOW(), 'Initial limit set by risk control');


### PR DESCRIPTION
## Summary

TRX-102. Gives `account-service` ownership of pre-trade risk limits: a `RiskLimits` table keyed on account, an append-only `RiskLimitHistory` trail, and `GET`/`PUT /account/{id}/risk-limit`.

**Why here and not in `trade-service`.** MiFID II RTS 6 Art. 15 requires pre-trade limits to be *set, owned and changed by a function independent of the desk that trades against them*, and RTS 6 Art. 12/16 require the firm to be able to show, after the fact, what limit was in force at the moment an order was assessed. Putting the limit in the service that enforces it would collapse that separation — the desk's own order path would be both the author and the arbiter of its constraint. So the authority (`account-service`, administered by risk/compliance) is deliberately a different service from the enforcement point (`trade-service`, TRX-101), which only ever reads. The history table exists for the same reason: an amendment that overwrites in place destroys the evidence a regulator asks for, so every accepted change appends a row recording the value, who set it, when, and why, and no row is ever updated or deleted.

**Shape of the change**

```
PUT /account/11413/risk-limit
{ "maxOrderNotional": 75000.00, "currency": "USD",
  "setBy": "head.of.risk@traderx", "reason": "Client uplift approved" }

RiskLimitService.setRiskLimit(id, req):        // @Transactional
    accountService.getAccountById(id)          // 404 for unknown account
    validate(req)                              // 400: notional >= 0, ISO currency, setBy present
    changeType = existing.isPresent() ? AMEND : CREATE
    riskLimitRepository.save(limit)            // current value
    riskLimitHistoryRepository.save(...)       // append-only row, never updated

GET /account/11413/risk-limit
{ "accountId": 11413, "limitPresent": true, "missingLimitPolicy": "UNLIMITED",
  "maxOrderNotional": 75000.00, "currency": "USD", "setBy": "...", "effectiveFrom": "...", "updated": "..." }
```

`GET` is 200 for any known account, including one with no limit — callers branch on `limitPresent`, not on the HTTP status, and read `missingLimitPolicy` to decide what "no limit" means (see below). `GET /account/{id}/risk-limit/history` returns the trail, most recent first, for TRX-105's compliance tab.

**Schema.** `database/initialSchema.sql` is append-only in this change: two new tables plus a `RISKLIMITHISTORY_SEQ` sequence and their seed rows. No existing table, column or seed row is touched, so every current flow behaves exactly as it does today. (The repo has no Liquibase — this file *is* the schema mechanism; if Liquibase is coming for this epic, this converts to a single additive changeset.) Table names follow the existing `AccountUsers`/`Positions` convention rather than the ticket's literal `risk_limit`.

**Seeds.** Account 11413 (`Private Clients Fund TTXX`) is seeded tight at USD 50,000 so a plausible 1,000-share order in a ~USD 100 name breaches it on stage. 22214, 42422, 52355 and 62654 get realistic headroom. 10031 and 44044 are deliberately left with no limit so the missing-limit path is visible.

**Config / flag.** No new runtime dependencies. Both knobs are externalised in `application.properties` and env-overridable: `traderx.risk-limit.enabled` (default `true`) and `traderx.risk-limit.missing-limit-policy` (default `UNLIMITED`). With `enabled=false` the service is indistinguishable from its pre-TRX-102 self: `GET` always reports no limit and `PUT` returns 503.

Tests cover get, put, amend-history, missing-limit, unknown account, validation, and the flag-off path. `./gradlew :account-service:build` passes (6 tests). The pre-existing `src/main/test/...AccountServiceApplicationTests.java` is outside Gradle's test source set and does not compile (`com.ms.sdx` imports); left untouched — new tests live in `src/test/java`.

## Decisions and open questions

Three things the ticket left open. I made the smallest defensible choice in each case and made it reversible; two of them need a human answer before this is anything other than a demo.

1. **Missing limit: "unlimited" or "reject everything"? — needs compliance.** Built as **`UNLIMITED` by default**, because fail-closed today would reject orders on the two accounts that have no limit and break existing flows, and because this PR only stores the limit — the decision is actually enforced in TRX-101. But that default is the wrong answer for a live venue: under RTS 6 Art. 15 an uncontrolled account is precisely the thing pre-trade controls exist to prevent, and "we had no limit configured" is not a defence. I therefore did **not** hard-code it — `missingLimitPolicy` is configuration, and it is returned in the `GET` payload so the enforcement side reads the firm's policy rather than assuming one. **Ask: should production run `REJECT`, with `UNLIMITED` only in dev?** If yes, the accounts currently seeded without limits need real limits before that flips.

2. **Per-account, per-trader or per-desk? — needs compliance.** Built **per-account**, as the ticket says, and that is the granularity the existing schema and the `trade-service` → `account-service` call already speak. But RTS 6 Art. 15 talks about limits per trader, per desk and firm-wide as well, and the `AccountUsers` table here is many-to-many: several traders share account 44044, so an account-level limit does not constrain any individual trader. **Ask: did compliance mean the account, or did they mean the trader/desk?** If trader or desk, the key on `RiskLimits` changes and the enforcement call in TRX-101 needs the trader identity in the request — cheaper to answer now than after TRX-101 lands.

3. **Amendment trail semantics — my call, flagging for visibility.** Each accepted change appends *one* row holding the newly effective value plus `changeType` (`CREATE`/`AMEND`), `changedBy` and `reason`; the superseded value survives as the preceding row rather than being duplicated into the amendment row. That reconstructs the limit in force at any past instant, which is what the audit requirement needs, without double-storing. It also means limits that pre-date this table would have no history row — not an issue here, since the seed data writes matching `CREATE` rows.

4. **Future-dated limits — my call, worth a product answer.** `effectiveFrom` was being stored and echoed but never compared to the clock, so a limit pre-loaded for next Monday would have governed today's trading. Smallest fix taken: `PUT` now rejects a future `effectiveFrom` with 400, so a stored limit is always the limit in force and the API says what it does. **Ask: do risk staff want to schedule limit changes ahead of time?** If so `RiskLimits` needs to become versioned (one row per account cannot hold both the current and the pending value) — cheap now, disruptive after TRX-101 reads it.

Also worth knowing: `PUT` records `setBy` from the request body and trusts it. There is no authentication in TraderX, so "who set this limit" is currently self-asserted — fine for the demo, but under RTS 6 the maker of a limit change has to be an authenticated, independent identity, and a real implementation would take it from the caller's principal (and likely want maker-checker on amendments). Out of scope here; called out so it isn't mistaken for done.


Link to Devin session: https://app.devin.ai/sessions/ebe20d3ccf3447f198ebe33a153c1498
Requested by: @chrischappell-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/98?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/traderxcognitiondemos/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->