### PR TITLE
TRX-104: Immutable best-execution audit record per order decision

### DIFF
--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -52,7 +52,11 @@ CREATE TABLE IF NOT EXISTS OrderDecisionAudit (
   SubmittedBy VARCHAR(50),
   -- WITH TIME ZONE so external readers (TRX-105, exports) see UTC rather than the
   -- session wall clock; Hibernate maps java.time.Instant to TIMESTAMP_UTC.
-  DecisionTimestamp TIMESTAMP(3) WITH TIME ZONE NOT NULL
+  DecisionTimestamp TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+  -- Full precision write time. One order can produce two records - an acceptance and then a
+  -- failure to reach the trade feed - inside the same millisecond, and the pair is only
+  -- readable if their order is unambiguous. This is the tie-break, not a regulatory field.
+  RecordedAt TIMESTAMP(6) WITH TIME ZONE NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -44,9 +44,11 @@ CREATE TABLE OrderDecisionAudit (
   LimitID VARCHAR(40),
   LimitType VARCHAR(40),
   LimitValue DECIMAL(23,4),
-  LimitEffectiveFrom TIMESTAMP(3),
+  LimitEffectiveFrom TIMESTAMP(3) WITH TIME ZONE,
   SubmittedBy VARCHAR(50),
-  DecisionTimestamp TIMESTAMP(3) NOT NULL
+  -- WITH TIME ZONE so external readers (TRX-105, exports) see UTC rather than the
+  -- session wall clock; Hibernate maps java.time.Instant to TIMESTAMP_UTC.
+  DecisionTimestamp TIMESTAMP(3) WITH TIME ZONE NOT NULL
 );
 
 CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -1,3 +1,5 @@
+Drop Table OrderDecisionAudit IF EXISTS;
+
 Drop Table Trades IF EXISTS;
 
 Drop Table AccountUsers IF EXISTS; 
@@ -18,9 +20,38 @@ CREATE TABLE Positions ( AccountID INTEGER , Security VARCHAR(15) , Updated TIME
 
 Alter Table Positions ADD FOREIGN KEY (AccountID) References Accounts(ID) ; 
 
-CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TIMESTAMP, Updated TIMESTAMP, Security VARCHAR (15) ,  Side VARCHAR(10) check (Side in ('Buy','Sell')),  Quantity INTEGER check Quantity > 0 , State VARCHAR(20) check (State in ('New', 'Processing', 'Settled', 'Cancelled'))) ;  
+CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TIMESTAMP, Updated TIMESTAMP, Security VARCHAR (15) ,  Side VARCHAR(10) check (Side in ('Buy','Sell')),  Quantity INTEGER check Quantity > 0 , State VARCHAR(20) check (State in ('New', 'Processing', 'Settled', 'Cancelled')), CorrelationID VARCHAR(50)) ;  
 
 Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID); 
+
+-- MiFID II Art. 16(6) / RTS 27-28 best-execution record. Append-only: written once by
+-- trade-service for every submission, accepted or rejected, and never updated or deleted.
+-- Deliberately has no foreign key to Accounts, because a rejected order may name an account
+-- that does not exist - that rejection still has to be reconstructable.
+CREATE TABLE OrderDecisionAudit (
+  ID VARCHAR(50) PRIMARY KEY,
+  CorrelationID VARCHAR(50) NOT NULL,
+  OrderID VARCHAR(50),
+  AccountID INTEGER,
+  Security VARCHAR(50),
+  Side VARCHAR(10),
+  Quantity INTEGER,
+  Price DECIMAL(19,4),
+  PriceSource VARCHAR(40),
+  Notional DECIMAL(23,4),
+  Decision VARCHAR(10) NOT NULL check (Decision in ('ACCEPTED','REJECTED')),
+  ReasonCode VARCHAR(40) NOT NULL,
+  LimitID VARCHAR(40),
+  LimitType VARCHAR(40),
+  LimitValue DECIMAL(23,4),
+  LimitEffectiveFrom TIMESTAMP(3),
+  SubmittedBy VARCHAR(50),
+  DecisionTimestamp TIMESTAMP(3) NOT NULL
+);
+
+CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);
+
+CREATE INDEX IDX_OrderDecisionAudit_Account_Time ON OrderDecisionAudit (AccountID, DecisionTimestamp);
 
 CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -29,7 +29,9 @@ Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID);
 --
 -- Note the absence of a DROP above, and IF NOT EXISTS below: this script re-runs on every
 -- database start, and every other table here is rebuilt from seed data. This one accumulates.
--- A retained record that a restart erases is not a retained record.
+-- A retained record that a restart erases is not a retained record. Note the limit of that
+-- claim in the demo stack: the H2 files live inside the container, so records survive a
+-- database restart but not a rebuild. Durable retention is an infrastructure follow-up.
 CREATE TABLE IF NOT EXISTS OrderDecisionAudit (
   ID VARCHAR(50) PRIMARY KEY,
   CorrelationID VARCHAR(50) NOT NULL,

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -1,5 +1,3 @@
-Drop Table OrderDecisionAudit IF EXISTS;
-
 Drop Table Trades IF EXISTS;
 
 Drop Table AccountUsers IF EXISTS; 
@@ -28,7 +26,11 @@ Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID);
 -- trade-service for every submission, accepted or rejected, and never updated or deleted.
 -- Deliberately has no foreign key to Accounts, because a rejected order may name an account
 -- that does not exist - that rejection still has to be reconstructable.
-CREATE TABLE OrderDecisionAudit (
+--
+-- Note the absence of a DROP above, and IF NOT EXISTS below: this script re-runs on every
+-- database start, and every other table here is rebuilt from seed data. This one accumulates.
+-- A retained record that a restart erases is not a retained record.
+CREATE TABLE IF NOT EXISTS OrderDecisionAudit (
   ID VARCHAR(50) PRIMARY KEY,
   CorrelationID VARCHAR(50) NOT NULL,
   OrderID VARCHAR(50),
@@ -51,9 +53,9 @@ CREATE TABLE OrderDecisionAudit (
   DecisionTimestamp TIMESTAMP(3) WITH TIME ZONE NOT NULL
 );
 
-CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);
+CREATE INDEX IF NOT EXISTS IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);
 
-CREATE INDEX IDX_OrderDecisionAudit_Account_Time ON OrderDecisionAudit (AccountID, DecisionTimestamp);
+CREATE INDEX IF NOT EXISTS IDX_OrderDecisionAudit_Account_Time ON OrderDecisionAudit (AccountID, DecisionTimestamp);
 
 CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/Trade.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/Trade.java
@@ -101,6 +101,18 @@ public class Trade implements Serializable {
 	}
 
 
+	/** Ties the booked trade back to its OrderDecisionAudit record written by trade-service. */
+	@Column(length = 50, name = "CORRELATIONID")
+	private String correlationId;
+
+	public String getCorrelationId() {
+		return this.correlationId;
+	}
+
+	public void setCorrelationId(String correlationId) {
+		this.correlationId = correlationId;
+	}
+
 	@Column(name = "CREATED")
 	private Date created;
 

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
@@ -8,6 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    private String correlationId;
 
     public TradeOrder(){}
     
@@ -41,5 +42,13 @@ public class TradeOrder {
 
     public TradeSide getSide() {
         return side;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 }

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
@@ -41,6 +41,7 @@ public class TradeService {
 		t.setId(UUID.randomUUID().toString());
 
 
+        t.setCorrelationId(order.getCorrelationId());
         t.setCreated(new Date());
         t.setUpdated(new Date());
         t.setSecurity(order.getSecurity());

--- a/trade-processor/src/test/java/finos/traderx/tradeprocessor/service/TradeServiceCorrelationTest.java
+++ b/trade-processor/src/test/java/finos/traderx/tradeprocessor/service/TradeServiceCorrelationTest.java
@@ -1,0 +1,72 @@
+package finos.traderx.tradeprocessor.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeprocessor.model.Position;
+import finos.traderx.tradeprocessor.model.Trade;
+import finos.traderx.tradeprocessor.model.TradeOrder;
+import finos.traderx.tradeprocessor.model.TradeSide;
+import finos.traderx.tradeprocessor.repository.PositionRepository;
+import finos.traderx.tradeprocessor.repository.TradeRepository;
+
+/**
+ * The audit record written at decision time is only useful if it can be tied to what was
+ * actually booked, so the correlation id has to survive the trip over the trade feed.
+ */
+class TradeServiceCorrelationTest {
+
+    private TradeRepository tradeRepository;
+    private PositionRepository positionRepository;
+    private TradeService tradeService;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        tradeRepository = mock(TradeRepository.class);
+        positionRepository = mock(PositionRepository.class);
+        when(tradeRepository.save(any(Trade.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(positionRepository.save(any(Position.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(positionRepository.findByAccountIdAndSecurity(anyInt(), anyString())).thenReturn(null);
+
+        tradeService = new TradeService();
+        ReflectionTestUtils.setField(tradeService, "tradeRepository", tradeRepository);
+        ReflectionTestUtils.setField(tradeService, "positionRepository", positionRepository);
+        ReflectionTestUtils.setField(tradeService, "tradePublisher", mock(Publisher.class));
+        ReflectionTestUtils.setField(tradeService, "positionPublisher", mock(Publisher.class));
+    }
+
+    @Test
+    void carriesTheDecisionCorrelationIdOntoTheBookedTrade() {
+        TradeOrder order = new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 100);
+        order.setCorrelationId("CORR-1");
+
+        Trade booked = tradeService.processTrade(order).getTrade();
+
+        assertEquals("CORR-1", booked.getCorrelationId());
+        ArgumentCaptor<Trade> captor = ArgumentCaptor.forClass(Trade.class);
+        verify(tradeRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
+        assertEquals("CORR-1", captor.getValue().getCorrelationId());
+    }
+
+    @Test
+    void leavesTheCorrelationIdUnsetForLegacyOrdersWithoutOne() {
+        TradeOrder order = new TradeOrder("ORDER-2", 22214, "MS", TradeSide.Sell, 50);
+
+        var result = tradeService.processTrade(order);
+
+        assertEquals(null, result.getTrade().getCorrelationId());
+        assertEquals(-50, result.getPosition().getQuantity());
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
@@ -1,0 +1,14 @@
+package finos.traderx.tradeservice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
@@ -1,5 +1,9 @@
 package finos.traderx.tradeservice;
 
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,8 +11,18 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class HttpClientConfig {
 
+    /**
+     * Timeouts are explicit because a hung validation service would otherwise leave a
+     * submission pending indefinitely, with no decision reached and so nothing to record.
+     * A bounded wait turns that into a VALIDATION_UNAVAILABLE record and a 503.
+     */
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder,
+            @Value("${lookup.connect.timeout.ms:2000}") long connectTimeoutMs,
+            @Value("${lookup.read.timeout.ms:5000}") long readTimeoutMs) {
+        return builder
+                .setConnectTimeout(Duration.ofMillis(connectTimeoutMs))
+                .setReadTimeout(Duration.ofMillis(readTimeoutMs))
+                .build();
     }
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/AuditConfig.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/AuditConfig.java
@@ -1,0 +1,18 @@
+package finos.traderx.tradeservice.audit;
+
+import java.time.Clock;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(BestExecutionAuditProperties.class)
+public class AuditConfig {
+
+    /** UTC, because the retained record has to be in UTC regardless of where the JVM runs. */
+    @Bean
+    public Clock auditClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -49,6 +49,11 @@ public class BestExecutionAuditProperties {
      */
     @PostConstruct
     void validate() {
+        // Normalised to the stored scale first, so the recorded notional is exactly the
+        // recorded price times quantity rather than the rounding of an unrecorded price.
+        if (pricing.getReferencePrice() != null) {
+            pricing.setReferencePrice(pricing.getReferencePrice().setScale(COLUMN_SCALE, RoundingMode.HALF_UP));
+        }
         requireStorable("audit.best-execution.limit.value", limit.getValue(), NOTIONAL_PRECISION);
         requireStorable("audit.best-execution.pricing.reference-price", pricing.getReferencePrice(),
                 PRICE_PRECISION);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -52,6 +52,11 @@ public class BestExecutionAuditProperties {
         requireStorable("audit.best-execution.limit.value", limit.getValue(), NOTIONAL_PRECISION);
         requireStorable("audit.best-execution.pricing.reference-price", pricing.getReferencePrice(),
                 PRICE_PRECISION);
+        // The stored notional is price x quantity, so the price has to fit the notional column
+        // at the largest quantity the order model can carry, not merely fit its own column.
+        requireStorable("audit.best-execution.pricing.reference-price (x max quantity)",
+                pricing.getReferencePrice().multiply(BigDecimal.valueOf(Integer.MAX_VALUE)),
+                NOTIONAL_PRECISION);
     }
 
     private static void requireStorable(String property, BigDecimal value, int precision) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -62,16 +62,21 @@ public class BestExecutionAuditProperties {
                 PRICE_PRECISION);
         // The stored notional is price x quantity, so the price has to fit the notional column
         // at the largest quantity the order model can carry, not merely fit its own column.
+        BigDecimal price = requireSet("audit.best-execution.pricing.reference-price", pricing.getReferencePrice());
         requireStorable("audit.best-execution.pricing.reference-price (x max quantity)",
-                pricing.getReferencePrice().multiply(BigDecimal.valueOf(Integer.MAX_VALUE)),
+                price.multiply(BigDecimal.valueOf(Integer.MAX_VALUE)),
                 NOTIONAL_PRECISION);
     }
 
-    private static void requireStorable(String property, BigDecimal value, int precision) {
+    private static BigDecimal requireSet(String property, BigDecimal value) {
         if (value == null) {
             throw new IllegalStateException(property + " must be set for the best-execution audit trail.");
         }
-        BigDecimal scaled = value.setScale(COLUMN_SCALE, RoundingMode.HALF_UP);
+        return value;
+    }
+
+    private static void requireStorable(String property, BigDecimal value, int precision) {
+        BigDecimal scaled = requireSet(property, value).setScale(COLUMN_SCALE, RoundingMode.HALF_UP);
         if (scaled.precision() - scaled.scale() > precision - COLUMN_SCALE) {
             throw new IllegalStateException(property + " does not fit the audit column DECIMAL(" + precision + ","
                     + COLUMN_SCALE + "): " + value);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -54,6 +54,9 @@ public class BestExecutionAuditProperties {
         if (pricing.getReferencePrice() != null) {
             pricing.setReferencePrice(pricing.getReferencePrice().setScale(COLUMN_SCALE, RoundingMode.HALF_UP));
         }
+        if (limit.getValue() != null) {
+            limit.setValue(limit.getValue().setScale(COLUMN_SCALE, RoundingMode.HALF_UP));
+        }
         requireStorable("audit.best-execution.limit.value", limit.getValue(), NOTIONAL_PRECISION);
         requireStorable("audit.best-execution.pricing.reference-price", pricing.getReferencePrice(),
                 PRICE_PRECISION);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -48,9 +48,16 @@ public class BestExecutionAuditProperties {
      * A misconfiguration is refused at startup rather than discovered when the first order is
      * recorded. That applies to the operator-supplied strings as well: truncating a limit id
      * would leave the record naming a limit that matches nothing in the limits store.
+     *
+     * Skipped when the feature is off, so the flag remains a way out of a bad deployment: none
+     * of these values is read once the audit write is disabled, and refusing to boot on them
+     * would leave an operator unable to submit orders at all.
      */
     @PostConstruct
     void validate() {
+        if (!enabled) {
+            return;
+        }
         // Normalised to the stored scale first, so the recorded notional is exactly the
         // recorded price times quantity rather than the rounding of an unrecorded price.
         if (pricing.getReferencePrice() != null) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -1,9 +1,12 @@
 package finos.traderx.tradeservice.audit;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * Externalised configuration for the best-execution audit trail. Nothing here is hard-coded
@@ -11,6 +14,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "audit.best-execution")
 public class BestExecutionAuditProperties {
+
+    private static final int COLUMN_SCALE = 4;
+    private static final int NOTIONAL_PRECISION = 23;
+    private static final int PRICE_PRECISION = 19;
 
     /** Kill switch for the whole feature. Defaults to on in dev. */
     private boolean enabled = true;
@@ -33,6 +40,29 @@ public class BestExecutionAuditProperties {
 
     public Pricing getPricing() {
         return pricing;
+    }
+
+    /**
+     * Unlike the string values, an over-large number cannot be fitted to its column without
+     * changing what the record says, so a misconfiguration is refused at startup rather than
+     * discovered when the first order fails to be recorded.
+     */
+    @PostConstruct
+    void validate() {
+        requireStorable("audit.best-execution.limit.value", limit.getValue(), NOTIONAL_PRECISION);
+        requireStorable("audit.best-execution.pricing.reference-price", pricing.getReferencePrice(),
+                PRICE_PRECISION);
+    }
+
+    private static void requireStorable(String property, BigDecimal value, int precision) {
+        if (value == null) {
+            throw new IllegalStateException(property + " must be set for the best-execution audit trail.");
+        }
+        BigDecimal scaled = value.setScale(COLUMN_SCALE, RoundingMode.HALF_UP);
+        if (scaled.precision() - scaled.scale() > precision - COLUMN_SCALE) {
+            throw new IllegalStateException(property + " does not fit the audit column DECIMAL(" + precision + ","
+                    + COLUMN_SCALE + "): " + value);
+        }
     }
 
     /**

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -18,6 +18,8 @@ public class BestExecutionAuditProperties {
     private static final int COLUMN_SCALE = 4;
     private static final int NOTIONAL_PRECISION = 23;
     private static final int PRICE_PRECISION = 19;
+    private static final int LIMIT_FIELD_MAX_LENGTH = 40;
+    private static final int PRICE_SOURCE_MAX_LENGTH = 40;
 
     /** Kill switch for the whole feature. Defaults to on in dev. */
     private boolean enabled = true;
@@ -43,9 +45,9 @@ public class BestExecutionAuditProperties {
     }
 
     /**
-     * Unlike the string values, an over-large number cannot be fitted to its column without
-     * changing what the record says, so a misconfiguration is refused at startup rather than
-     * discovered when the first order fails to be recorded.
+     * A misconfiguration is refused at startup rather than discovered when the first order is
+     * recorded. That applies to the operator-supplied strings as well: truncating a limit id
+     * would leave the record naming a limit that matches nothing in the limits store.
      */
     @PostConstruct
     void validate() {
@@ -66,6 +68,16 @@ public class BestExecutionAuditProperties {
         requireStorable("audit.best-execution.pricing.reference-price (x max quantity)",
                 price.multiply(BigDecimal.valueOf(Integer.MAX_VALUE)),
                 NOTIONAL_PRECISION);
+        requireFits("audit.best-execution.limit.id", limit.getId(), LIMIT_FIELD_MAX_LENGTH);
+        requireFits("audit.best-execution.limit.type", limit.getType(), LIMIT_FIELD_MAX_LENGTH);
+        requireFits("audit.best-execution.pricing.source", pricing.getSource(), PRICE_SOURCE_MAX_LENGTH);
+    }
+
+    private static void requireFits(String property, String value, int maxLength) {
+        if (value != null && value.length() > maxLength) {
+            throw new IllegalStateException(property + " is longer than the " + maxLength
+                    + " characters the audit column stores: " + value);
+        }
     }
 
     private static BigDecimal requireSet(String property, BigDecimal value) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -1,0 +1,105 @@
+package finos.traderx.tradeservice.audit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Externalised configuration for the best-execution audit trail. Nothing here is hard-coded
+ * in the decision path; see application.properties for the dev defaults.
+ */
+@ConfigurationProperties(prefix = "audit.best-execution")
+public class BestExecutionAuditProperties {
+
+    /** Kill switch for the whole feature. Defaults to on in dev. */
+    private boolean enabled = true;
+
+    private final Limit limit = new Limit();
+
+    private final Pricing pricing = new Pricing();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Limit getLimit() {
+        return limit;
+    }
+
+    public Pricing getPricing() {
+        return pricing;
+    }
+
+    /**
+     * The limit snapshot recorded against each decision until TRX-102 provides a real
+     * limits store to read from.
+     */
+    public static class Limit {
+        private String id = "DEFAULT-ACCOUNT-NOTIONAL";
+        private String type = "ACCOUNT_NOTIONAL";
+        private BigDecimal value = new BigDecimal("5000000.0000");
+        private Instant effectiveFrom = Instant.parse("2024-01-01T00:00:00Z");
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public BigDecimal getValue() {
+            return value;
+        }
+
+        public void setValue(BigDecimal value) {
+            this.value = value;
+        }
+
+        public Instant getEffectiveFrom() {
+            return effectiveFrom;
+        }
+
+        public void setEffectiveFrom(Instant effectiveFrom) {
+            this.effectiveFrom = effectiveFrom;
+        }
+    }
+
+    /**
+     * TraderX has no market data service, so the price used to compute notional comes from
+     * configuration and is labelled as such in every record.
+     */
+    public static class Pricing {
+        private BigDecimal referencePrice = new BigDecimal("100.0000");
+        private String source = "CONFIGURED_STATIC_REFERENCE_PRICE";
+
+        public BigDecimal getReferencePrice() {
+            return referencePrice;
+        }
+
+        public void setReferencePrice(BigDecimal referencePrice) {
+            this.referencePrice = referencePrice;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -32,6 +32,8 @@ public class OrderDecisionAuditService {
 
     private static final int ID_MAX_LENGTH = 50;
     private static final int SECURITY_MAX_LENGTH = 50;
+    private static final int LIMIT_FIELD_MAX_LENGTH = 40;
+    private static final int PRICE_SOURCE_MAX_LENGTH = 40;
 
     private final OrderDecisionAuditRepository repository;
     private final BestExecutionAuditProperties properties;
@@ -54,7 +56,11 @@ public class OrderDecisionAuditService {
 
         BigDecimal price = properties.getPricing().getReferencePrice();
         BigDecimal notional = notionalOf(order, price);
-        EvaluatedLimit limit = new EvaluatedLimit(properties.getLimit().getId(), properties.getLimit().getType(),
+        // Configured values are fitted too: a misconfigured limit name must not be able to fail
+        // the insert, because that would fail every order submission rather than one record.
+        EvaluatedLimit limit = new EvaluatedLimit(
+                fitToColumn(properties.getLimit().getId(), LIMIT_FIELD_MAX_LENGTH),
+                fitToColumn(properties.getLimit().getType(), LIMIT_FIELD_MAX_LENGTH),
                 properties.getLimit().getValue(), properties.getLimit().getEffectiveFrom());
 
         OrderDecisionAudit auditRecord = new OrderDecisionAudit(
@@ -66,7 +72,7 @@ public class OrderDecisionAuditService {
                 order.getSide() == null ? null : order.getSide().toString(),
                 order.getQuantity(),
                 price,
-                properties.getPricing().getSource(),
+                fitToColumn(properties.getPricing().getSource(), PRICE_SOURCE_MAX_LENGTH),
                 notional,
                 decision,
                 reason,
@@ -88,8 +94,17 @@ public class OrderDecisionAuditService {
         if (value == null || value.length() <= maxLength) {
             return value;
         }
-        log.warn("Truncating value to {} characters for the audit record; original was [{}]", maxLength, value);
+        log.warn("Truncating value to {} characters for the audit record; original was [{}]", maxLength,
+                forLogging(value));
         return value.substring(0, maxLength);
+    }
+
+    /**
+     * Client supplied text reaches the operational log, which is itself part of how a decision
+     * gets reconstructed, so line breaks are neutralised rather than allowed to forge entries.
+     */
+    private String forLogging(String value) {
+        return value.replaceAll("[\\r\\n]", "_");
     }
 
     private BigDecimal notionalOf(TradeOrder order, BigDecimal price) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -36,6 +36,7 @@ public class OrderDecisionAuditService {
     private static final int LIMIT_FIELD_MAX_LENGTH = 40;
     private static final int PRICE_SOURCE_MAX_LENGTH = 40;
     private static final int SUBMITTED_BY_MAX_LENGTH = 50;
+    private static final int LOG_EXCERPT_LENGTH = 100;
 
     private final OrderDecisionAuditRepository repository;
     private final BestExecutionAuditProperties properties;
@@ -59,8 +60,8 @@ public class OrderDecisionAuditService {
 
         BigDecimal price = properties.getPricing().getReferencePrice();
         BigDecimal notional = notionalOf(order, price);
-        // Configured values are fitted too: a misconfigured limit name must not be able to fail
-        // the insert, because that would fail every order submission rather than one record.
+        // Configured values go through fitToColumn as a last resort only; an over-long one is
+        // refused at startup, because a truncated limit id names a limit that matches nothing.
         EvaluatedLimit limit = new EvaluatedLimit(
                 fitToColumn(properties.getLimit().getId(), LIMIT_FIELD_MAX_LENGTH),
                 fitToColumn(properties.getLimit().getType(), LIMIT_FIELD_MAX_LENGTH),
@@ -105,14 +106,18 @@ public class OrderDecisionAuditService {
     /**
      * Client supplied values are recorded as far as the column allows rather than being
      * allowed to fail the insert: a refusal to store the record is the one outcome the
-     * regulatory trail cannot have.
+     * regulatory trail cannot have. Configured values pass through here too, but cannot
+     * reach it overlong - {@link BestExecutionAuditProperties} refuses those at startup,
+     * where the operator can still act on them.
      */
     private String fitToColumn(String value, int maxLength) {
         if (value == null || value.length() <= maxLength) {
             return value;
         }
-        log.warn("Truncating value to {} characters for the audit record; original was [{}]", maxLength,
-                forLogging(value));
+        // Only an excerpt: the value can be a client header of unbounded length, and a single
+        // log line long enough to be a problem in itself helps no one reconstruct anything.
+        log.warn("Truncating a {} character value to {} for the audit record; it began [{}]", value.length(),
+                maxLength, forLogging(value.substring(0, Math.min(value.length(), LOG_EXCERPT_LENGTH))));
         return value.substring(0, maxLength);
     }
 

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -1,0 +1,85 @@
+package finos.traderx.tradeservice.audit;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.EvaluatedLimit;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+import finos.traderx.tradeservice.repository.OrderDecisionAuditRepository;
+
+/**
+ * Writes the append-only best-execution record for every order submission.
+ *
+ * The write is synchronous with the decision and commits in its own transaction, so the
+ * record survives a later failure in the same request (a publish error, for instance).
+ */
+@Service
+public class OrderDecisionAuditService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderDecisionAuditService.class);
+
+    private final OrderDecisionAuditRepository repository;
+    private final BestExecutionAuditProperties properties;
+    private final Clock clock;
+
+    public OrderDecisionAuditService(OrderDecisionAuditRepository repository,
+            BestExecutionAuditProperties properties, Clock clock) {
+        this.repository = repository;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public OrderDecisionAudit recordDecision(TradeOrder order, String correlationId, DecisionOutcome decision,
+            DecisionReason reason, String submittedBy) {
+        if (!properties.isEnabled()) {
+            log.warn("Best-execution audit disabled; no record written for correlation id {}", correlationId);
+            return null;
+        }
+
+        BigDecimal price = properties.getPricing().getReferencePrice();
+        BigDecimal notional = notionalOf(order, price);
+        EvaluatedLimit limit = new EvaluatedLimit(properties.getLimit().getId(), properties.getLimit().getType(),
+                properties.getLimit().getValue(), properties.getLimit().getEffectiveFrom());
+
+        OrderDecisionAudit auditRecord = new OrderDecisionAudit(
+                UUID.randomUUID().toString(),
+                correlationId,
+                order.getId(),
+                order.getAccountId(),
+                order.getSecurity(),
+                order.getSide() == null ? null : order.getSide().toString(),
+                order.getQuantity(),
+                price,
+                properties.getPricing().getSource(),
+                notional,
+                decision,
+                reason,
+                limit,
+                submittedBy,
+                Instant.now(clock).truncatedTo(ChronoUnit.MILLIS));
+
+        OrderDecisionAudit saved = repository.save(auditRecord);
+        log.info("Best-execution audit record written: {}", saved);
+        return saved;
+    }
+
+    private BigDecimal notionalOf(TradeOrder order, BigDecimal price) {
+        if (order.getQuantity() == null || price == null) {
+            return null;
+        }
+        return price.multiply(BigDecimal.valueOf(order.getQuantity()));
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -45,7 +45,7 @@ public class OrderDecisionAuditService {
     public OrderDecisionAudit recordDecision(TradeOrder order, String correlationId, DecisionOutcome decision,
             DecisionReason reason, String submittedBy) {
         if (!properties.isEnabled()) {
-            log.warn("Best-execution audit disabled; no record written for correlation id {}", correlationId);
+            log.debug("Best-execution audit disabled; no record written for correlation id {}", correlationId);
             return null;
         }
 

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -34,6 +34,7 @@ public class OrderDecisionAuditService {
     private static final int SECURITY_MAX_LENGTH = 50;
     private static final int LIMIT_FIELD_MAX_LENGTH = 40;
     private static final int PRICE_SOURCE_MAX_LENGTH = 40;
+    private static final int SUBMITTED_BY_MAX_LENGTH = 50;
 
     private final OrderDecisionAuditRepository repository;
     private final BestExecutionAuditProperties properties;
@@ -77,7 +78,7 @@ public class OrderDecisionAuditService {
                 decision,
                 reason,
                 limit,
-                submittedBy,
+                fitToColumn(submittedBy, SUBMITTED_BY_MAX_LENGTH),
                 Instant.now(clock).truncatedTo(ChronoUnit.MILLIS));
 
         OrderDecisionAudit saved = repository.save(auditRecord);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -88,7 +88,7 @@ public class OrderDecisionAuditService {
         if (value == null || value.length() <= maxLength) {
             return value;
         }
-        log.warn("Truncating value of length {} to {} characters for the audit record", value.length(), maxLength);
+        log.warn("Truncating value to {} characters for the audit record; original was [{}]", maxLength, value);
         return value.substring(0, maxLength);
     }
 

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -30,6 +30,9 @@ public class OrderDecisionAuditService {
 
     private static final Logger log = LoggerFactory.getLogger(OrderDecisionAuditService.class);
 
+    private static final int ID_MAX_LENGTH = 50;
+    private static final int SECURITY_MAX_LENGTH = 50;
+
     private final OrderDecisionAuditRepository repository;
     private final BestExecutionAuditProperties properties;
     private final Clock clock;
@@ -57,9 +60,9 @@ public class OrderDecisionAuditService {
         OrderDecisionAudit auditRecord = new OrderDecisionAudit(
                 UUID.randomUUID().toString(),
                 correlationId,
-                order.getId(),
+                fitToColumn(order.getId(), ID_MAX_LENGTH),
                 order.getAccountId(),
-                order.getSecurity(),
+                fitToColumn(order.getSecurity(), SECURITY_MAX_LENGTH),
                 order.getSide() == null ? null : order.getSide().toString(),
                 order.getQuantity(),
                 price,
@@ -74,6 +77,19 @@ public class OrderDecisionAuditService {
         OrderDecisionAudit saved = repository.save(auditRecord);
         log.info("Best-execution audit record written: {}", saved);
         return saved;
+    }
+
+    /**
+     * Client supplied values are recorded as far as the column allows rather than being
+     * allowed to fail the insert: a refusal to store the record is the one outcome the
+     * regulatory trail cannot have.
+     */
+    private String fitToColumn(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        log.warn("Truncating value of length {} to {} characters for the audit record", value.length(), maxLength);
+        return value.substring(0, maxLength);
     }
 
     private BigDecimal notionalOf(TradeOrder order, BigDecimal price) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -66,7 +66,7 @@ public class OrderDecisionAuditService {
 
         OrderDecisionAudit auditRecord = new OrderDecisionAudit(
                 UUID.randomUUID().toString(),
-                correlationId,
+                fitToColumn(correlationId, ID_MAX_LENGTH),
                 fitToColumn(order.getId(), ID_MAX_LENGTH),
                 order.getAccountId(),
                 fitToColumn(order.getSecurity(), SECURITY_MAX_LENGTH),

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -5,6 +5,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,7 @@ public class OrderDecisionAuditService {
     private final OrderDecisionAuditRepository repository;
     private final BestExecutionAuditProperties properties;
     private final Clock clock;
+    private final AtomicReference<Instant> lastRecordedAt = new AtomicReference<>();
 
     public OrderDecisionAuditService(OrderDecisionAuditRepository repository,
             BestExecutionAuditProperties properties, Clock clock) {
@@ -79,11 +81,25 @@ public class OrderDecisionAuditService {
                 reason,
                 limit,
                 fitToColumn(submittedBy, SUBMITTED_BY_MAX_LENGTH),
-                Instant.now(clock).truncatedTo(ChronoUnit.MILLIS));
+                Instant.now(clock).truncatedTo(ChronoUnit.MILLIS),
+                nextRecordedAt());
 
         OrderDecisionAudit saved = repository.save(auditRecord);
         log.info("Best-execution audit record written: {}", saved);
         return saved;
+    }
+
+    /**
+     * The regulatory timestamp is truncated to milliseconds, so an accepted order and the
+     * dispatch failure that follows it can share one. This is the ordering key: strictly
+     * increasing within the process that wrote the pair, at the microsecond resolution the
+     * column stores, so the sequence of records under one correlation id is unambiguous.
+     */
+    private Instant nextRecordedAt() {
+        return lastRecordedAt.updateAndGet(previous -> {
+            Instant now = Instant.now(clock).truncatedTo(ChronoUnit.MICROS);
+            return previous == null || now.isAfter(previous) ? now : previous.plus(1, ChronoUnit.MICROS);
+        });
     }
 
     /**

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -136,6 +136,19 @@ public class TradeOrderController {
 		}
 	}
 
+	/**
+	 * Classifies a non-404 client error. Only a complaint about the request itself is the
+	 * submitter's fault; an expired credential or a rate limit is our own availability
+	 * problem, and the retained record must not blame the trader for it.
+	 */
+	private LookupResult classify(HttpClientErrorException ex)
+	{
+		return switch (ex.getStatusCode().value()) {
+			case 400, 422 -> LookupResult.INVALID_SUBMISSION;
+			default -> LookupResult.UNAVAILABLE;
+		};
+	}
+
 	private String submittedBy(String submittingUser)
 	{
 		if (submittingUser == null || submittingUser.isBlank()) {
@@ -149,11 +162,13 @@ public class TradeOrderController {
 	{
 		// Move whole method to a sperate class that handles all reference data 
 		// so we can mock it and run without this service up.
-		String url = this.referenceDataServiceAddress + "//stocks/" + ticker;
+		// The ticker is a free-form client string, so it is passed as a URI variable and
+		// encoded rather than concatenated into the path.
+		String url = this.referenceDataServiceAddress + "//stocks/{ticker}";
 		ResponseEntity<Security> response = null;
 
 		try {
-			response = this.restTemplate.getForEntity(url, Security.class);
+			response = this.restTemplate.getForEntity(url, Security.class, ticker);
 			log.info("Validate ticker " + String.valueOf(response.getBody()));
 			return LookupResult.FOUND;
 		}
@@ -162,10 +177,8 @@ public class TradeOrderController {
 				log.info(ticker + " not found in reference data service.");
 				return LookupResult.NOT_FOUND;
 			}
-			// A 4xx that is not a 404 means the service understood us and objected: that is a
-			// bad submission, not an outage, and the audit record has to say so.
 			log.error(ex.getMessage());
-			return LookupResult.INVALID_SUBMISSION;
+			return classify(ex);
 		}
 		catch (RestClientException ex) {
 			log.error("Reference data service unavailable while validating " + ticker, ex);
@@ -178,12 +191,12 @@ public class TradeOrderController {
 		// Move whole method to a sperate class that handles all accounts 
 		// so we can mock it and run without this service up.
 
-		String url = this.accountServiceAddress + "//account/" + id;
+		String url = this.accountServiceAddress + "//account/{id}";
 		ResponseEntity<Account> response = null;
 
 		try 
 		{
-				response = this.restTemplate.getForEntity(url, Account.class);
+				response = this.restTemplate.getForEntity(url, Account.class, id);
 				log.info("Validate account " + String.valueOf(response.getBody()));
 				return LookupResult.FOUND;
 		}
@@ -193,7 +206,7 @@ public class TradeOrderController {
 				return LookupResult.NOT_FOUND;
 			}
 			log.error(ex.getMessage());
-			return LookupResult.INVALID_SUBMISSION;
+			return classify(ex);
 		}
 		catch (RestClientException ex) {
 			log.error("Account service unavailable while validating account " + id, ex);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -83,6 +83,16 @@ public class TradeOrderController {
 		tradeOrder.setCorrelationId(correlationId);
 		String submittedBy = submittedBy(submittingUser);
 
+		// Checked before any lookup, so a submission missing a security or an account is filed
+		// as the submitter's error rather than being classified by whatever status a downstream
+		// service happens to return for an empty path segment.
+		if (tradeOrder.getSecurity() == null || tradeOrder.getSecurity().isBlank() || tradeOrder.getAccountId() == null)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.SUBMISSION_INVALID, submittedBy);
+			throw new InvalidSubmissionException("A trade order must carry both a security and an account id.");
+		}
+
 		LookupResult tickerLookup = validateTicker(tradeOrder.getSecurity());
 		if (tickerLookup == LookupResult.UNAVAILABLE)
 		{

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -137,11 +137,12 @@ public class TradeOrderController {
 				log.info("Trade is valid. Submitting {}", tradeOrder);
 				tradePublisher.publish("/trades",tradeOrder);
 				return  ResponseEntity.ok(tradeOrder);
-			}  catch (PubSubException e){
+			}  catch (PubSubException | RuntimeException e){
 				// The accepted record has already committed and cannot be amended, so the fact that
 				// the order never reached the feed is appended as a second record under the same
 				// correlation id. Without it the trail would show an accepted order that the trader
-				// saw fail and that was never booked.
+				// saw fail and that was never booked. Any runtime failure is caught, not only
+				// PubSubException, so the guarantee holds whichever publisher is wired in.
 				orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 						DecisionReason.DISPATCH_FAILED, submittedBy);
 				throw new RuntimeException("Failed to publish trade order", e);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -82,15 +82,16 @@ public class TradeOrderController {
 
 		// Checked before any lookup, so a submission missing a security or an account is filed
 		// as the submitter's error rather than being classified by whatever status a downstream
-		// service happens to return for an empty path segment. Quantity is checked here too: the
-		// Trades table refuses a non-positive quantity, so such an order cannot book, and without
-		// this it would be recorded as accepted and then quietly fail in trade-processor.
+		// service happens to return for an empty path segment. Quantity and side are checked here
+		// too: a non-positive quantity cannot book, and a missing side books as a sale, since
+		// trade-processor treats anything that is not Buy as a Sell and a CHECK constraint passes
+		// on NULL. Either would be recorded as accepted while the trade did something else.
 		if (tradeOrder.getSecurity() == null || tradeOrder.getSecurity().isBlank() || tradeOrder.getAccountId() == null
-				|| tradeOrder.getQuantity() == null || tradeOrder.getQuantity() <= 0)
+				|| tradeOrder.getSide() == null || tradeOrder.getQuantity() == null || tradeOrder.getQuantity() <= 0)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SUBMISSION_INVALID, submittedBy);
-			throw new InvalidSubmissionException("A trade order must carry a security, an account id and a positive quantity.");
+			throw new InvalidSubmissionException("A trade order must carry a security, an account id, a side and a positive quantity.");
 		}
 
 		LookupResult tickerLookup = validateTicker(tradeOrder.getSecurity());

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 import finos.traderx.messaging.PubSubException;
 import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
+import finos.traderx.tradeservice.exceptions.ValidationUnavailableException;
 import finos.traderx.tradeservice.model.Account;
 import finos.traderx.tradeservice.model.Security;
 import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
@@ -84,7 +85,7 @@ public class TradeOrderController {
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
-			throw new RuntimeException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
+			throw new ValidationUnavailableException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
 		}
 		else if (tickerLookup == LookupResult.NOT_FOUND) 
 		{
@@ -98,7 +99,7 @@ public class TradeOrderController {
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
-			throw new RuntimeException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
+			throw new ValidationUnavailableException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
 		}
 		else if(accountLookup == LookupResult.NOT_FOUND)
 		{
@@ -138,7 +139,7 @@ public class TradeOrderController {
 
 		try {
 			response = this.restTemplate.getForEntity(url, Security.class);
-			log.info("Validate ticker " + response.getBody().toString());
+			log.info("Validate ticker " + String.valueOf(response.getBody()));
 			return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
@@ -166,7 +167,7 @@ public class TradeOrderController {
 		try 
 		{
 				response = this.restTemplate.getForEntity(url, Account.class);
-				log.info("Validate account " + response.getBody().toString());
+				log.info("Validate account " + String.valueOf(response.getBody()));
 				return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import finos.traderx.messaging.PubSubException;
@@ -38,13 +39,29 @@ public class TradeOrderController {
 	private static final String SUBMITTING_USER_HEADER = "X-TraderX-User";
 	private static final String UNKNOWN_USER = "UNKNOWN";
 
-	@Autowired
-	private Publisher<TradeOrder> tradePublisher;
+	/** Length of the SUBMITTEDBY column; an over-long header must not fail the audit insert. */
+	private static final int SUBMITTED_BY_MAX_LENGTH = 50;
+
+	private final Publisher<TradeOrder> tradePublisher;
+
+	private final OrderDecisionAuditService orderDecisionAuditService;
+
+	private final RestTemplate restTemplate;
 
 	@Autowired
-	private OrderDecisionAuditService orderDecisionAuditService;
-	
-	private RestTemplate restTemplate = new RestTemplate();
+	public TradeOrderController(Publisher<TradeOrder> tradePublisher,
+			OrderDecisionAuditService orderDecisionAuditService, RestTemplate restTemplate) {
+		this.tradePublisher = tradePublisher;
+		this.orderDecisionAuditService = orderDecisionAuditService;
+		this.restTemplate = restTemplate;
+	}
+
+	/** Outcome of a downstream existence check. "Not found" and "could not ask" are different facts. */
+	enum LookupResult {
+		FOUND,
+		NOT_FOUND,
+		UNAVAILABLE
+	}
 
 	@Value("${reference.data.service.url}")
 	private String referenceDataServiceAddress;
@@ -60,15 +77,30 @@ public class TradeOrderController {
 
 		String correlationId = UUID.randomUUID().toString();
 		tradeOrder.setCorrelationId(correlationId);
-		String submittedBy = (submittingUser == null || submittingUser.isBlank()) ? UNKNOWN_USER : submittingUser;
+		String submittedBy = submittedBy(submittingUser);
 
-		if (!validateTicker(tradeOrder.getSecurity())) 
+		LookupResult tickerLookup = validateTicker(tradeOrder.getSecurity());
+		if (tickerLookup == LookupResult.UNAVAILABLE)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
+			throw new RuntimeException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
+		}
+		else if (tickerLookup == LookupResult.NOT_FOUND) 
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SECURITY_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");
 		}
-		else if(!validateAccount(tradeOrder.getAccountId()))
+
+		LookupResult accountLookup = validateAccount(tradeOrder.getAccountId());
+		if (accountLookup == LookupResult.UNAVAILABLE)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
+			throw new RuntimeException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
+		}
+		else if(accountLookup == LookupResult.NOT_FOUND)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.ACCOUNT_NOT_FOUND, submittedBy);
@@ -88,7 +120,16 @@ public class TradeOrderController {
 		}
 	}
 
-	private boolean validateTicker(String ticker)
+	private String submittedBy(String submittingUser)
+	{
+		if (submittingUser == null || submittingUser.isBlank()) {
+			return UNKNOWN_USER;
+		}
+		String trimmed = submittingUser.trim();
+		return trimmed.length() > SUBMITTED_BY_MAX_LENGTH ? trimmed.substring(0, SUBMITTED_BY_MAX_LENGTH) : trimmed;
+	}
+
+	private LookupResult validateTicker(String ticker)
 	{
 		// Move whole method to a sperate class that handles all reference data 
 		// so we can mock it and run without this service up.
@@ -98,20 +139,23 @@ public class TradeOrderController {
 		try {
 			response = this.restTemplate.getForEntity(url, Security.class);
 			log.info("Validate ticker " + response.getBody().toString());
-			return true;
+			return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
+			if (ex.getStatusCode().value() == 404) {
 				log.info(ticker + " not found in reference data service.");
+				return LookupResult.NOT_FOUND;
 			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
+			log.error(ex.getMessage());
+			return LookupResult.UNAVAILABLE;
+		}
+		catch (RestClientException ex) {
+			log.error("Reference data service unavailable while validating " + ticker, ex);
+			return LookupResult.UNAVAILABLE;
 		}
 	}		
 	
-	private boolean validateAccount(Integer id)
+	private LookupResult validateAccount(Integer id)
 	{
 		// Move whole method to a sperate class that handles all accounts 
 		// so we can mock it and run without this service up.
@@ -123,16 +167,19 @@ public class TradeOrderController {
 		{
 				response = this.restTemplate.getForEntity(url, Account.class);
 				log.info("Validate account " + response.getBody().toString());
-				return true;
+				return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
+			if (ex.getStatusCode().value() == 404) {
 				log.info("Account" + id + " not found in account service.");				
+				return LookupResult.NOT_FOUND;
 			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
+			log.error(ex.getMessage());
+			return LookupResult.UNAVAILABLE;
+		}
+		catch (RestClientException ex) {
+			log.error("Account service unavailable while validating account " + id, ex);
+			return LookupResult.UNAVAILABLE;
 		}
 	}
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 import finos.traderx.messaging.PubSubException;
 import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
+import finos.traderx.tradeservice.exceptions.InvalidSubmissionException;
 import finos.traderx.tradeservice.exceptions.ValidationUnavailableException;
 import finos.traderx.tradeservice.model.Account;
 import finos.traderx.tradeservice.model.Security;
@@ -61,6 +62,8 @@ public class TradeOrderController {
 	enum LookupResult {
 		FOUND,
 		NOT_FOUND,
+		/** The lookup service refused the question — the submission itself is malformed. */
+		INVALID_SUBMISSION,
 		UNAVAILABLE
 	}
 
@@ -87,6 +90,12 @@ public class TradeOrderController {
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
 			throw new ValidationUnavailableException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
 		}
+		else if (tickerLookup == LookupResult.INVALID_SUBMISSION)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.SUBMISSION_INVALID, submittedBy);
+			throw new InvalidSubmissionException("Reference data service rejected the lookup for " + tradeOrder.getSecurity() + ".");
+		}
 		else if (tickerLookup == LookupResult.NOT_FOUND) 
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
@@ -100,6 +109,12 @@ public class TradeOrderController {
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
 			throw new ValidationUnavailableException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
+		}
+		else if (accountLookup == LookupResult.INVALID_SUBMISSION)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.SUBMISSION_INVALID, submittedBy);
+			throw new InvalidSubmissionException("Account service rejected the lookup for account " + tradeOrder.getAccountId() + ".");
 		}
 		else if(accountLookup == LookupResult.NOT_FOUND)
 		{
@@ -147,8 +162,10 @@ public class TradeOrderController {
 				log.info(ticker + " not found in reference data service.");
 				return LookupResult.NOT_FOUND;
 			}
+			// A 4xx that is not a 404 means the service understood us and objected: that is a
+			// bad submission, not an outage, and the audit record has to say so.
 			log.error(ex.getMessage());
-			return LookupResult.UNAVAILABLE;
+			return LookupResult.INVALID_SUBMISSION;
 		}
 		catch (RestClientException ex) {
 			log.error("Reference data service unavailable while validating " + ticker, ex);
@@ -176,7 +193,7 @@ public class TradeOrderController {
 				return LookupResult.NOT_FOUND;
 			}
 			log.error(ex.getMessage());
-			return LookupResult.UNAVAILABLE;
+			return LookupResult.INVALID_SUBMISSION;
 		}
 		catch (RestClientException ex) {
 			log.error("Account service unavailable while validating account " + id, ex);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -82,12 +82,15 @@ public class TradeOrderController {
 
 		// Checked before any lookup, so a submission missing a security or an account is filed
 		// as the submitter's error rather than being classified by whatever status a downstream
-		// service happens to return for an empty path segment.
-		if (tradeOrder.getSecurity() == null || tradeOrder.getSecurity().isBlank() || tradeOrder.getAccountId() == null)
+		// service happens to return for an empty path segment. Quantity is checked here too: the
+		// Trades table refuses a non-positive quantity, so such an order cannot book, and without
+		// this it would be recorded as accepted and then quietly fail in trade-processor.
+		if (tradeOrder.getSecurity() == null || tradeOrder.getSecurity().isBlank() || tradeOrder.getAccountId() == null
+				|| tradeOrder.getQuantity() == null || tradeOrder.getQuantity() <= 0)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SUBMISSION_INVALID, submittedBy);
-			throw new InvalidSubmissionException("A trade order must carry both a security and an account id.");
+			throw new InvalidSubmissionException("A trade order must carry a security, an account id and a positive quantity.");
 		}
 
 		LookupResult tickerLookup = validateTicker(tradeOrder.getSecurity());
@@ -95,13 +98,15 @@ public class TradeOrderController {
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
-			throw new ValidationUnavailableException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
+			// The submitted values are in the audit record under this correlation id rather than
+			// reflected back in the response body.
+			throw new ValidationUnavailableException("Could not validate the security against Reference data service. Correlation id " + correlationId + ".");
 		}
 		else if (tickerLookup == LookupResult.INVALID_SUBMISSION)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SUBMISSION_INVALID, submittedBy);
-			throw new InvalidSubmissionException("Reference data service rejected the lookup for " + tradeOrder.getSecurity() + ".");
+			throw new InvalidSubmissionException("Reference data service rejected the security lookup. Correlation id " + correlationId + ".");
 		}
 		else if (tickerLookup == LookupResult.NOT_FOUND) 
 		{
@@ -115,13 +120,13 @@ public class TradeOrderController {
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
-			throw new ValidationUnavailableException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
+			throw new ValidationUnavailableException("Could not validate the account against Account service. Correlation id " + correlationId + ".");
 		}
 		else if (accountLookup == LookupResult.INVALID_SUBMISSION)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SUBMISSION_INVALID, submittedBy);
-			throw new InvalidSubmissionException("Account service rejected the lookup for account " + tradeOrder.getAccountId() + ".");
+			throw new InvalidSubmissionException("Account service rejected the account lookup. Correlation id " + correlationId + ".");
 		}
 		else if(accountLookup == LookupResult.NOT_FOUND)
 		{

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -169,6 +169,15 @@ public class TradeOrderController {
 		};
 	}
 
+	/**
+	 * The operational log is part of how a decision is reconstructed, so a client string must
+	 * not be able to introduce line breaks and forge entries in it.
+	 */
+	private String forLogging(String value)
+	{
+		return value == null ? null : value.replaceAll("[\\r\\n]", "_");
+	}
+
 	private String submittedBy(String submittingUser)
 	{
 		if (submittingUser == null || submittingUser.isBlank()) {
@@ -192,7 +201,7 @@ public class TradeOrderController {
 			if (response.getBody() == null) {
 				// A 2xx with nothing in it does not confirm the security exists, and an order
 				// that was never confirmed must not be recorded as validated.
-				log.error("Reference data service returned an empty body for " + ticker);
+				log.error("Reference data service returned an empty body for {}", forLogging(ticker));
 				return LookupResult.UNAVAILABLE;
 			}
 			log.info("Validate ticker " + response.getBody());
@@ -200,14 +209,14 @@ public class TradeOrderController {
 		}
 		catch (HttpClientErrorException ex) {
 			if (ex.getStatusCode().value() == 404) {
-				log.info(ticker + " not found in reference data service.");
+				log.info("{} not found in reference data service.", forLogging(ticker));
 				return LookupResult.NOT_FOUND;
 			}
 			log.error(ex.getMessage());
 			return classify(ex);
 		}
 		catch (RestClientException ex) {
-			log.error("Reference data service unavailable while validating " + ticker, ex);
+			log.error("Reference data service unavailable while validating {}", forLogging(ticker), ex);
 			return LookupResult.UNAVAILABLE;
 		}
 	}		

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -138,6 +138,12 @@ public class TradeOrderController {
 				tradePublisher.publish("/trades",tradeOrder);
 				return  ResponseEntity.ok(tradeOrder);
 			}  catch (PubSubException e){
+				// The accepted record has already committed and cannot be amended, so the fact that
+				// the order never reached the feed is appended as a second record under the same
+				// correlation id. Without it the trail would show an accepted order that the trader
+				// saw fail and that was never booked.
+				orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+						DecisionReason.DISPATCH_FAILED, submittedBy);
 				throw new RuntimeException("Failed to publish trade order", e);
 			}
 		}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -143,8 +143,14 @@ public class TradeOrderController {
 				// correlation id. Without it the trail would show an accepted order that the trader
 				// saw fail and that was never booked. Any runtime failure is caught, not only
 				// PubSubException, so the guarantee holds whichever publisher is wired in.
-				orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
-						DecisionReason.DISPATCH_FAILED, submittedBy);
+				try {
+					orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+							DecisionReason.DISPATCH_FAILED, submittedBy);
+				} catch (RuntimeException auditFailure) {
+					// Losing the record is bad; losing the reason the order never went out is worse,
+					// so the original publish failure is still what propagates.
+					log.error("Could not record the dispatch failure for correlation id {}", correlationId, auditFailure);
+				}
 				throw new RuntimeException("Failed to publish trade order", e);
 			}
 		}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -1,5 +1,7 @@
 package finos.traderx.tradeservice.controller;
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -18,7 +21,10 @@ import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
 import finos.traderx.tradeservice.model.Account;
 import finos.traderx.tradeservice.model.Security;
+import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
 import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -29,8 +35,14 @@ public class TradeOrderController {
 
 	private static final Logger log = LoggerFactory.getLogger(TradeOrderController.class);
 
+	private static final String SUBMITTING_USER_HEADER = "X-TraderX-User";
+	private static final String UNKNOWN_USER = "UNKNOWN";
+
 	@Autowired
 	private Publisher<TradeOrder> tradePublisher;
+
+	@Autowired
+	private OrderDecisionAuditService orderDecisionAuditService;
 	
 	private RestTemplate restTemplate = new RestTemplate();
 
@@ -42,19 +54,30 @@ public class TradeOrderController {
 
 	@Operation(description = "Submit a new trade order")
 	@PostMapping("/")
-	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder) {
+	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder,
+			@Parameter(description = "user submitting the order, recorded in the audit trail") @RequestHeader(value = SUBMITTING_USER_HEADER, required = false) String submittingUser) {
 		log.info("Called createTradeOrder");
-		
+
+		String correlationId = UUID.randomUUID().toString();
+		tradeOrder.setCorrelationId(correlationId);
+		String submittedBy = (submittingUser == null || submittingUser.isBlank()) ? UNKNOWN_USER : submittingUser;
+
 		if (!validateTicker(tradeOrder.getSecurity())) 
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.SECURITY_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");
 		}
 		else if(!validateAccount(tradeOrder.getAccountId()))
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.ACCOUNT_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getAccountId() + " not found in Account service.");
 		}
 		else
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.ACCEPTED,
+					DecisionReason.VALIDATED, submittedBy);
 			try{
 				log.info("Trade is valid. Submitting {}", tradeOrder);
 				tradePublisher.publish("/trades",tradeOrder);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -41,9 +41,6 @@ public class TradeOrderController {
 	private static final String SUBMITTING_USER_HEADER = "X-TraderX-User";
 	private static final String UNKNOWN_USER = "UNKNOWN";
 
-	/** Length of the SUBMITTEDBY column; an over-long header must not fail the audit insert. */
-	private static final int SUBMITTED_BY_MAX_LENGTH = 50;
-
 	private final Publisher<TradeOrder> tradePublisher;
 
 	private final OrderDecisionAuditService orderDecisionAuditService;
@@ -164,8 +161,8 @@ public class TradeOrderController {
 		if (submittingUser == null || submittingUser.isBlank()) {
 			return UNKNOWN_USER;
 		}
-		String trimmed = submittingUser.trim();
-		return trimmed.length() > SUBMITTED_BY_MAX_LENGTH ? trimmed.substring(0, SUBMITTED_BY_MAX_LENGTH) : trimmed;
+		// Length is bounded by the audit service, alongside every other value it stores.
+		return submittingUser.trim();
 	}
 
 	private LookupResult validateTicker(String ticker)
@@ -179,7 +176,13 @@ public class TradeOrderController {
 
 		try {
 			response = this.restTemplate.getForEntity(url, Security.class, ticker);
-			log.info("Validate ticker " + String.valueOf(response.getBody()));
+			if (response.getBody() == null) {
+				// A 2xx with nothing in it does not confirm the security exists, and an order
+				// that was never confirmed must not be recorded as validated.
+				log.error("Reference data service returned an empty body for " + ticker);
+				return LookupResult.UNAVAILABLE;
+			}
+			log.info("Validate ticker " + response.getBody());
 			return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
@@ -207,7 +210,11 @@ public class TradeOrderController {
 		try 
 		{
 				response = this.restTemplate.getForEntity(url, Account.class, id);
-				log.info("Validate account " + String.valueOf(response.getBody()));
+				if (response.getBody() == null) {
+					log.error("Account service returned an empty body for account " + id);
+					return LookupResult.UNAVAILABLE;
+				}
+				log.info("Validate account " + response.getBody());
 				return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {

--- a/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/InvalidSubmissionException.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/InvalidSubmissionException.java
@@ -1,0 +1,17 @@
+package finos.traderx.tradeservice.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * A lookup service understood the question and objected to it, so the submission itself is
+ * malformed. Distinct from {@link ValidationUnavailableException}, which means we could not
+ * ask at all — the audit record must not confuse a bad order with an outage.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidSubmissionException extends RuntimeException {
+
+    public InvalidSubmissionException(String message) {
+        super(message);
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/ValidationUnavailableException.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/exceptions/ValidationUnavailableException.java
@@ -1,0 +1,17 @@
+package finos.traderx.tradeservice.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * A downstream check could not be performed, so the order was refused without being validated.
+ * Distinct from {@link ResourceNotFoundException}: the order is not known to be invalid, we
+ * were unable to establish whether it is.
+ */
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class ValidationUnavailableException extends RuntimeException {
+
+    public ValidationUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
@@ -8,6 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    private String correlationId;
 
     public TradeOrder(){}
     
@@ -41,5 +42,13 @@ public class TradeOrder {
 
     public TradeSide getSide() {
         return side;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
@@ -1,5 +1,7 @@
 package finos.traderx.tradeservice.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class TradeOrder {
 
     public String id;
@@ -8,6 +10,8 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
+            description = "Assigned by trade-service and ties the order to its audit record; any value sent by a client is replaced.")
     private String correlationId;
 
     public TradeOrder(){}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionOutcome.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionOutcome.java
@@ -1,0 +1,6 @@
+package finos.traderx.tradeservice.model.audit;
+
+public enum DecisionOutcome {
+    ACCEPTED,
+    REJECTED
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -1,0 +1,11 @@
+package finos.traderx.tradeservice.model.audit;
+
+/**
+ * Machine readable reason attached to every order decision. Values are part of the
+ * retained regulatory record and must not be renamed once written.
+ */
+public enum DecisionReason {
+    VALIDATED,
+    SECURITY_NOT_FOUND,
+    ACCOUNT_NOT_FOUND
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -11,5 +11,10 @@ public enum DecisionReason {
     /** A downstream check could not be performed, so the order was refused without being validated. */
     VALIDATION_UNAVAILABLE,
     /** A downstream check rejected the request itself, so the submission was malformed. */
-    SUBMISSION_INVALID
+    SUBMISSION_INVALID,
+    /**
+     * The order was validated, but could not be handed to the trade feed. Appended after the
+     * ACCEPTED record under the same correlation id, since neither record can be amended.
+     */
+    DISPATCH_FAILED
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -9,5 +9,7 @@ public enum DecisionReason {
     SECURITY_NOT_FOUND,
     ACCOUNT_NOT_FOUND,
     /** A downstream check could not be performed, so the order was refused without being validated. */
-    VALIDATION_UNAVAILABLE
+    VALIDATION_UNAVAILABLE,
+    /** A downstream check rejected the request itself, so the submission was malformed. */
+    SUBMISSION_INVALID
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -7,5 +7,7 @@ package finos.traderx.tradeservice.model.audit;
 public enum DecisionReason {
     VALIDATED,
     SECURITY_NOT_FOUND,
-    ACCOUNT_NOT_FOUND
+    ACCOUNT_NOT_FOUND,
+    /** A downstream check could not be performed, so the order was refused without being validated. */
+    VALIDATION_UNAVAILABLE
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/EvaluatedLimit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/EvaluatedLimit.java
@@ -1,0 +1,11 @@
+package finos.traderx.tradeservice.model.audit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Snapshot of the limit that was in force when a decision was taken. Copied into the audit
+ * record by value so the decision stays reconstructable after the limit is later amended.
+ */
+public record EvaluatedLimit(String limitId, String limitType, BigDecimal limitValue, Instant effectiveFrom) {
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
@@ -1,0 +1,204 @@
+package finos.traderx.tradeservice.model.audit;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.hibernate.annotations.Immutable;
+import org.springframework.data.domain.Persistable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Append-only record of a single order decision, retained under MiFID II Art. 16(6).
+ *
+ * Immutability is enforced in three places: Hibernate never issues an UPDATE for an
+ * {@link Immutable} entity, every column is mapped {@code updatable = false}, and the type
+ * exposes no setters. The repository deliberately exposes no delete operation.
+ */
+@Entity
+@Immutable
+@Table(name = "ORDERDECISIONAUDIT")
+public class OrderDecisionAudit implements Persistable<String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", length = 50, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "CORRELATIONID", length = 50, updatable = false, nullable = false)
+    private String correlationId;
+
+    @Column(name = "ORDERID", length = 50, updatable = false)
+    private String orderId;
+
+    @Column(name = "ACCOUNTID", updatable = false)
+    private Integer accountId;
+
+    @Column(name = "SECURITY", length = 50, updatable = false)
+    private String security;
+
+    @Column(name = "SIDE", length = 10, updatable = false)
+    private String side;
+
+    @Column(name = "QUANTITY", updatable = false)
+    private Integer quantity;
+
+    @Column(name = "PRICE", precision = 19, scale = 4, updatable = false)
+    private BigDecimal price;
+
+    @Column(name = "PRICESOURCE", length = 40, updatable = false)
+    private String priceSource;
+
+    @Column(name = "NOTIONAL", precision = 23, scale = 4, updatable = false)
+    private BigDecimal notional;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "DECISION", length = 10, updatable = false, nullable = false)
+    private DecisionOutcome decision;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "REASONCODE", length = 40, updatable = false, nullable = false)
+    private DecisionReason reasonCode;
+
+    @Column(name = "LIMITID", length = 40, updatable = false)
+    private String limitId;
+
+    @Column(name = "LIMITTYPE", length = 40, updatable = false)
+    private String limitType;
+
+    @Column(name = "LIMITVALUE", precision = 23, scale = 4, updatable = false)
+    private BigDecimal limitValue;
+
+    @Column(name = "LIMITEFFECTIVEFROM", updatable = false)
+    private Instant limitEffectiveFrom;
+
+    @Column(name = "SUBMITTEDBY", length = 50, updatable = false)
+    private String submittedBy;
+
+    @Column(name = "DECISIONTIMESTAMP", updatable = false, nullable = false)
+    private Instant decisionTimestamp;
+
+    protected OrderDecisionAudit() {
+    }
+
+    public OrderDecisionAudit(String id, String correlationId, String orderId, Integer accountId, String security,
+            String side, Integer quantity, BigDecimal price, String priceSource, BigDecimal notional,
+            DecisionOutcome decision, DecisionReason reasonCode, EvaluatedLimit limit, String submittedBy,
+            Instant decisionTimestamp) {
+        this.id = id;
+        this.correlationId = correlationId;
+        this.orderId = orderId;
+        this.accountId = accountId;
+        this.security = security;
+        this.side = side;
+        this.quantity = quantity;
+        this.price = price;
+        this.priceSource = priceSource;
+        this.notional = notional;
+        this.decision = decision;
+        this.reasonCode = reasonCode;
+        if (limit != null) {
+            this.limitId = limit.limitId();
+            this.limitType = limit.limitType();
+            this.limitValue = limit.limitValue();
+            this.limitEffectiveFrom = limit.effectiveFrom();
+        }
+        this.submittedBy = submittedBy;
+        this.decisionTimestamp = decisionTimestamp;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Always new. An audit record is inserted once and never merged back, so the persistence
+     * provider must never be given the chance to turn a save into an UPDATE.
+     */
+    @Override
+    public boolean isNew() {
+        return true;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public Integer getAccountId() {
+        return accountId;
+    }
+
+    public String getSecurity() {
+        return security;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getPriceSource() {
+        return priceSource;
+    }
+
+    public BigDecimal getNotional() {
+        return notional;
+    }
+
+    public DecisionOutcome getDecision() {
+        return decision;
+    }
+
+    public DecisionReason getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getLimitId() {
+        return limitId;
+    }
+
+    public String getLimitType() {
+        return limitType;
+    }
+
+    public BigDecimal getLimitValue() {
+        return limitValue;
+    }
+
+    public Instant getLimitEffectiveFrom() {
+        return limitEffectiveFrom;
+    }
+
+    public String getSubmittedBy() {
+        return submittedBy;
+    }
+
+    public Instant getDecisionTimestamp() {
+        return decisionTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderDecisionAudit[id=%s, correlationId=%s, decision=%s, reason=%s, account=%s, security=%s, notional=%s]"
+                .formatted(id, correlationId, decision, reasonCode, accountId, security, notional);
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import org.hibernate.annotations.Check;
 import org.hibernate.annotations.Immutable;
 import org.springframework.data.domain.Persistable;
 
@@ -12,6 +13,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 
 /**
@@ -23,7 +25,14 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Immutable
-@Table(name = "ORDERDECISIONAUDIT")
+// The constraint and indexes are declared here as well as in initialSchema.sql: if this service
+// ever reaches a database where the script has not run, Hibernate creates the table from this
+// mapping, and a later script run skips it. The retained table must not end up the weaker one.
+@Check(constraints = "DECISION IN ('ACCEPTED','REJECTED')")
+@Table(name = "ORDERDECISIONAUDIT", indexes = {
+        @Index(name = "IDX_OrderDecisionAudit_Correlation", columnList = "CORRELATIONID"),
+        @Index(name = "IDX_OrderDecisionAudit_Account_Time", columnList = "ACCOUNTID, DECISIONTIMESTAMP")
+})
 public class OrderDecisionAudit implements Persistable<String>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
@@ -94,13 +94,21 @@ public class OrderDecisionAudit implements Persistable<String>, Serializable {
     @Column(name = "DECISIONTIMESTAMP", updatable = false, nullable = false)
     private Instant decisionTimestamp;
 
+    /**
+     * The decision timestamp is the regulatory field and is deliberately truncated to
+     * milliseconds, which means two records for one order can share it. This is the full
+     * precision write time, kept solely so the pair has a deterministic order.
+     */
+    @Column(name = "RECORDEDAT", updatable = false, nullable = false)
+    private Instant recordedAt;
+
     protected OrderDecisionAudit() {
     }
 
     public OrderDecisionAudit(String id, String correlationId, String orderId, Integer accountId, String security,
             String side, Integer quantity, BigDecimal price, String priceSource, BigDecimal notional,
             DecisionOutcome decision, DecisionReason reasonCode, EvaluatedLimit limit, String submittedBy,
-            Instant decisionTimestamp) {
+            Instant decisionTimestamp, Instant recordedAt) {
         this.id = id;
         this.correlationId = correlationId;
         this.orderId = orderId;
@@ -121,6 +129,7 @@ public class OrderDecisionAudit implements Persistable<String>, Serializable {
         }
         this.submittedBy = submittedBy;
         this.decisionTimestamp = decisionTimestamp;
+        this.recordedAt = recordedAt;
     }
 
     @Override
@@ -203,6 +212,10 @@ public class OrderDecisionAudit implements Persistable<String>, Serializable {
 
     public Instant getDecisionTimestamp() {
         return decisionTimestamp;
+    }
+
+    public Instant getRecordedAt() {
+        return recordedAt;
     }
 
     @Override

--- a/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
@@ -25,8 +25,10 @@ public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAu
      * Ordered, because one correlation id can carry more than one record: an accepted order
      * that then failed to reach the trade feed is two rows, and the sequence is what makes the
      * pair readable. An unordered list would let a caller read the accept and miss the failure.
+     * The secondary key breaks the tie when both rows fall in the same millisecond, which for
+     * a synchronous publish failure is the normal case rather than the rare one.
      */
-    List<OrderDecisionAudit> findByCorrelationIdOrderByDecisionTimestampAsc(String correlationId);
+    List<OrderDecisionAudit> findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc(String correlationId);
 
-    List<OrderDecisionAudit> findByAccountIdOrderByDecisionTimestampAsc(Integer accountId);
+    List<OrderDecisionAudit> findByAccountIdOrderByDecisionTimestampAscRecordedAtAsc(Integer accountId);
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
@@ -21,7 +21,12 @@ public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAu
 
     Optional<OrderDecisionAudit> findById(String id);
 
-    List<OrderDecisionAudit> findByCorrelationId(String correlationId);
+    /**
+     * Ordered, because one correlation id can carry more than one record: an accepted order
+     * that then failed to reach the trade feed is two rows, and the sequence is what makes the
+     * pair readable. An unordered list would let a caller read the accept and miss the failure.
+     */
+    List<OrderDecisionAudit> findByCorrelationIdOrderByDecisionTimestampAsc(String correlationId);
 
-    List<OrderDecisionAudit> findByAccountId(Integer accountId);
+    List<OrderDecisionAudit> findByAccountIdOrderByDecisionTimestampAsc(Integer accountId);
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
@@ -1,0 +1,27 @@
+package finos.traderx.tradeservice.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+
+/**
+ * Append-only access to the best-execution audit trail.
+ *
+ * This extends the bare {@link Repository} marker rather than {@code JpaRepository} on
+ * purpose: inheriting {@code CrudRepository} would expose {@code delete}, {@code deleteAll}
+ * and {@code saveAll}-style mutation to any caller in the service. Only the four methods
+ * declared here exist.
+ */
+public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
+
+    OrderDecisionAudit save(OrderDecisionAudit auditRecord);
+
+    Optional<OrderDecisionAudit> findById(String id);
+
+    List<OrderDecisionAudit> findByCorrelationId(String correlationId);
+
+    List<OrderDecisionAudit> findByAccountId(Integer accountId);
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
@@ -25,10 +25,13 @@ public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAu
      * Ordered, because one correlation id can carry more than one record: an accepted order
      * that then failed to reach the trade feed is two rows, and the sequence is what makes the
      * pair readable. An unordered list would let a caller read the accept and miss the failure.
-     * The secondary key breaks the tie when both rows fall in the same millisecond, which for
-     * a synchronous publish failure is the normal case rather than the rare one.
+     *
+     * Ordered by the append key alone rather than by decision time: the two rows are written
+     * in one request and usually share a millisecond, and the wall clock they come from can
+     * step backwards under an NTP correction, which would invert the pair. RecordedAt cannot.
      */
-    List<OrderDecisionAudit> findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc(String correlationId);
+    List<OrderDecisionAudit> findByCorrelationIdOrderByRecordedAtAsc(String correlationId);
 
+    /** By decision time, which is the question an account-level enquiry asks, then by append order. */
     List<OrderDecisionAudit> findByAccountIdOrderByDecisionTimestampAscRecordedAtAsc(Integer accountId);
 }

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -7,6 +7,25 @@ reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_
 
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 
+# The best-execution audit trail is persisted in the shared TraderX database, alongside the
+# trades it explains, rather than in a service-local store.
+spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=${DATABASE_DBUSER:sa}
+spring.datasource.password=${DATABASE_DBPASS:sa}
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+# MiFID II RTS 27/28 best-execution audit trail (TRX-104). Single kill switch, on in dev.
+audit.best-execution.enabled=${BEST_EXECUTION_AUDIT_ENABLED:true}
+audit.best-execution.limit.id=${BEST_EXECUTION_LIMIT_ID:DEFAULT-ACCOUNT-NOTIONAL}
+audit.best-execution.limit.type=${BEST_EXECUTION_LIMIT_TYPE:ACCOUNT_NOTIONAL}
+audit.best-execution.limit.value=${BEST_EXECUTION_LIMIT_VALUE:5000000.0000}
+audit.best-execution.limit.effective-from=${BEST_EXECUTION_LIMIT_EFFECTIVE_FROM:2024-01-01T00:00:00Z}
+audit.best-execution.pricing.reference-price=${BEST_EXECUTION_REFERENCE_PRICE:100.0000}
+audit.best-execution.pricing.source=${BEST_EXECUTION_PRICE_SOURCE:CONFIGURED_STATIC_REFERENCE_PRICE}
+
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000
 

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -7,6 +7,11 @@ reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_
 
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 
+# Bounded waits on the validation lookups: a hung service must become a recorded
+# VALIDATION_UNAVAILABLE decision rather than a submission that never concludes.
+lookup.connect.timeout.ms=${LOOKUP_CONNECT_TIMEOUT_MS:2000}
+lookup.read.timeout.ms=${LOOKUP_READ_TIMEOUT_MS:5000}
+
 # The best-execution audit trail is persisted in the shared TraderX database, alongside the
 # trades it explains, rather than in a service-local store.
 spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -30,6 +30,16 @@ class BestExecutionAuditPropertiesTest {
     }
 
     @Test
+    void normalisesTheConfiguredLimitToTheScaleItIsStoredAt() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getLimit().setValue(new BigDecimal("5000000.00005"));
+
+        properties.validate();
+
+        assertEquals(new BigDecimal("5000000.0001"), properties.getLimit().getValue());
+    }
+
+    @Test
     void refusesALimitTooLargeForTheAuditColumn() {
         BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
         properties.getLimit().setValue(new BigDecimal("1".repeat(20)));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -40,6 +40,15 @@ class BestExecutionAuditPropertiesTest {
     }
 
     @Test
+    void doesNotBlockStartupOnABadSettingOnceTheFeatureIsSwitchedOff() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.setEnabled(false);
+        properties.getPricing().setReferencePrice(null);
+
+        assertDoesNotThrow(properties::validate);
+    }
+
+    @Test
     void refusesALimitIdTooLongForTheAuditColumnRatherThanRecordingATruncatedOne() {
         BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
         properties.getLimit().setId("L".repeat(41));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -40,6 +40,14 @@ class BestExecutionAuditPropertiesTest {
     }
 
     @Test
+    void refusesALimitIdTooLongForTheAuditColumnRatherThanRecordingATruncatedOne() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getLimit().setId("L".repeat(41));
+
+        assertThrows(IllegalStateException.class, properties::validate);
+    }
+
+    @Test
     void refusesALimitTooLargeForTheAuditColumn() {
         BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
         properties.getLimit().setValue(new BigDecimal("1".repeat(20)));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -1,0 +1,36 @@
+package finos.traderx.tradeservice.audit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A number too large for its audit column would fail every insert, and the audit write is
+ * deliberately fail-closed, so it must be refused at startup rather than at the first order.
+ */
+class BestExecutionAuditPropertiesTest {
+
+    @Test
+    void acceptsTheConfiguredDevDefaults() {
+        assertDoesNotThrow(new BestExecutionAuditProperties()::validate);
+    }
+
+    @Test
+    void refusesALimitTooLargeForTheAuditColumn() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getLimit().setValue(new BigDecimal("1".repeat(20)));
+
+        assertThrows(IllegalStateException.class, properties::validate);
+    }
+
+    @Test
+    void refusesAReferencePriceTooLargeForTheAuditColumn() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getPricing().setReferencePrice(new BigDecimal("1".repeat(16)));
+
+        assertThrows(IllegalStateException.class, properties::validate);
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -27,6 +27,14 @@ class BestExecutionAuditPropertiesTest {
     }
 
     @Test
+    void refusesAPriceThatFitsItsOwnColumnButOverflowsNotionalAtMaxQuantity() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getPricing().setReferencePrice(new BigDecimal("1".repeat(15)));
+
+        assertThrows(IllegalStateException.class, properties::validate);
+    }
+
+    @Test
     void refusesAReferencePriceTooLargeForTheAuditColumn() {
         BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
         properties.getPricing().setReferencePrice(new BigDecimal("1".repeat(16)));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/BestExecutionAuditPropertiesTest.java
@@ -1,6 +1,7 @@
 package finos.traderx.tradeservice.audit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
@@ -16,6 +17,16 @@ class BestExecutionAuditPropertiesTest {
     @Test
     void acceptsTheConfiguredDevDefaults() {
         assertDoesNotThrow(new BestExecutionAuditProperties()::validate);
+    }
+
+    @Test
+    void normalisesTheConfiguredPriceToTheScaleItIsStoredAt() {
+        BestExecutionAuditProperties properties = new BestExecutionAuditProperties();
+        properties.getPricing().setReferencePrice(new BigDecimal("100.00005"));
+
+        properties.validate();
+
+        assertEquals(new BigDecimal("100.0001"), properties.getPricing().getReferencePrice());
     }
 
     @Test

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
@@ -92,6 +92,18 @@ class OrderDecisionAuditServiceTest {
     }
 
     @Test
+    void fitsOverlongValuesToTheirColumnsRatherThanFailingTheInsert() {
+        TradeOrder order = new TradeOrder("O".repeat(80), 22214, "S".repeat(80), TradeSide.Buy, 1);
+
+        OrderDecisionAudit record = service.recordDecision(order, "CORR-4", DecisionOutcome.REJECTED,
+                DecisionReason.SUBMISSION_INVALID, "u".repeat(200));
+
+        assertEquals(50, record.getOrderId().length());
+        assertEquals(50, record.getSecurity().length());
+        assertEquals(50, record.getSubmittedBy().length());
+    }
+
+    @Test
     void writesNothingWhenTheFeatureFlagIsOff() {
         properties.setEnabled(false);
 

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
@@ -92,6 +92,19 @@ class OrderDecisionAuditServiceTest {
     }
 
     @Test
+    void twoRecordsForOneOrderGetADistinctOrderingKeyEvenOnTheSameClockTick() {
+        TradeOrder order = new TradeOrder("ORDER-3", 22214, "IBM", TradeSide.Buy, 10);
+
+        OrderDecisionAudit accepted = service.recordDecision(order, "CORR-3", DecisionOutcome.ACCEPTED,
+                DecisionReason.VALIDATED, "user04");
+        OrderDecisionAudit dispatchFailed = service.recordDecision(order, "CORR-3", DecisionOutcome.REJECTED,
+                DecisionReason.DISPATCH_FAILED, "user04");
+
+        assertEquals(accepted.getDecisionTimestamp(), dispatchFailed.getDecisionTimestamp());
+        assertTrue(dispatchFailed.getRecordedAt().isAfter(accepted.getRecordedAt()));
+    }
+
+    @Test
     void fitsOverlongValuesToTheirColumnsRatherThanFailingTheInsert() {
         TradeOrder order = new TradeOrder("O".repeat(80), 22214, "S".repeat(80), TradeSide.Buy, 1);
 

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
@@ -1,0 +1,115 @@
+package finos.traderx.tradeservice.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.TradeSide;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+import finos.traderx.tradeservice.repository.OrderDecisionAuditRepository;
+
+class OrderDecisionAuditServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-08-12T09:15:30.123456Z");
+
+    private OrderDecisionAuditRepository repository;
+    private BestExecutionAuditProperties properties;
+    private OrderDecisionAuditService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(OrderDecisionAuditRepository.class);
+        when(repository.save(any(OrderDecisionAudit.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        properties = new BestExecutionAuditProperties();
+        properties.getPricing().setReferencePrice(new BigDecimal("12.5000"));
+        properties.getLimit().setValue(new BigDecimal("1000000.0000"));
+        properties.getLimit().setEffectiveFrom(Instant.parse("2025-04-01T00:00:00Z"));
+        service = new OrderDecisionAuditService(repository, properties,
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    void recordsAnAcceptedDecisionWithNotionalPriceAndLimitSnapshot() {
+        TradeOrder order = new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 400);
+
+        OrderDecisionAudit record = service.recordDecision(order, "CORR-1", DecisionOutcome.ACCEPTED,
+                DecisionReason.VALIDATED, "user01");
+
+        assertNotNull(record.getId());
+        assertEquals("CORR-1", record.getCorrelationId());
+        assertEquals("ORDER-1", record.getOrderId());
+        assertEquals(22214, record.getAccountId());
+        assertEquals("IBM", record.getSecurity());
+        assertEquals("Buy", record.getSide());
+        assertEquals(400, record.getQuantity());
+        assertEquals(new BigDecimal("12.5000"), record.getPrice());
+        assertEquals(0, new BigDecimal("5000.0000").compareTo(record.getNotional()));
+        assertEquals("CONFIGURED_STATIC_REFERENCE_PRICE", record.getPriceSource());
+        assertEquals(DecisionOutcome.ACCEPTED, record.getDecision());
+        assertEquals(DecisionReason.VALIDATED, record.getReasonCode());
+        assertEquals("DEFAULT-ACCOUNT-NOTIONAL", record.getLimitId());
+        assertEquals("ACCOUNT_NOTIONAL", record.getLimitType());
+        assertEquals(new BigDecimal("1000000.0000"), record.getLimitValue());
+        assertEquals(Instant.parse("2025-04-01T00:00:00Z"), record.getLimitEffectiveFrom());
+        assertEquals("user01", record.getSubmittedBy());
+        assertEquals(Instant.parse("2026-08-12T09:15:30.123Z"), record.getDecisionTimestamp());
+    }
+
+    @Test
+    void recordsARejectedDecisionForAnOrderThatNeverExists() {
+        TradeOrder order = new TradeOrder("ORDER-2", 99999, "NOSUCH", TradeSide.Sell, 10);
+
+        service.recordDecision(order, "CORR-2", DecisionOutcome.REJECTED, DecisionReason.ACCOUNT_NOT_FOUND, "user03");
+
+        ArgumentCaptor<OrderDecisionAudit> captor = ArgumentCaptor.forClass(OrderDecisionAudit.class);
+        verify(repository).save(captor.capture());
+        OrderDecisionAudit record = captor.getValue();
+        assertEquals(DecisionOutcome.REJECTED, record.getDecision());
+        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, record.getReasonCode());
+        assertEquals(99999, record.getAccountId());
+        assertEquals("CORR-2", record.getCorrelationId());
+        assertEquals("user03", record.getSubmittedBy());
+    }
+
+    @Test
+    void writesNothingWhenTheFeatureFlagIsOff() {
+        properties.setEnabled(false);
+
+        assertNull(service.recordDecision(new TradeOrder("ORDER-3", 22214, "IBM", TradeSide.Buy, 1), "CORR-3",
+                DecisionOutcome.ACCEPTED, DecisionReason.VALIDATED, "user01"));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void auditRecordExposesNoMutatorsAndTheRepositoryExposesNoDeletes() {
+        for (Method method : OrderDecisionAudit.class.getDeclaredMethods()) {
+            assertTrue(!method.getName().startsWith("set"),
+                    "OrderDecisionAudit must stay append-only but declares " + method.getName());
+        }
+        for (Method method : OrderDecisionAuditRepository.class.getMethods()) {
+            assertTrue(!method.getName().toLowerCase().contains("delete")
+                    && !method.getName().toLowerCase().contains("remove"),
+                    "Audit repository must expose no delete path but declares " + method.getName());
+        }
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -1,0 +1,142 @@
+package finos.traderx.tradeservice.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
+import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.TradeSide;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+
+/**
+ * Every exit path from the submission endpoint must leave exactly one audit record behind,
+ * including the paths where a downstream lookup could not be performed at all.
+ */
+class TradeOrderControllerAuditTest {
+
+    private static final String REFERENCE_DATA_URL = "http://reference-data";
+    private static final String ACCOUNT_URL = "http://account-service";
+
+    private OrderDecisionAuditService auditService;
+    private Publisher<TradeOrder> publisher;
+    private RestTemplate restTemplate;
+    private MockRestServiceServer downstream;
+    private TradeOrderController controller;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        auditService = mock(OrderDecisionAuditService.class);
+        publisher = mock(Publisher.class);
+        restTemplate = new RestTemplate();
+        downstream = MockRestServiceServer.bindTo(restTemplate).build();
+        controller = new TradeOrderController(publisher, auditService, restTemplate);
+        ReflectionTestUtils.setField(controller, "referenceDataServiceAddress", REFERENCE_DATA_URL);
+        ReflectionTestUtils.setField(controller, "accountServiceAddress", ACCOUNT_URL);
+    }
+
+    private TradeOrder order() {
+        return new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 100);
+    }
+
+    private DecisionReason capturedReason(DecisionOutcome expectedOutcome) {
+        ArgumentCaptor<DecisionReason> reason = ArgumentCaptor.forClass(DecisionReason.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), eq(expectedOutcome), reason.capture(),
+                anyString());
+        return reason.getValue();
+    }
+
+    @Test
+    void anAcceptedOrderIsAuditedAndCarriesACorrelationId() throws Exception {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withSuccess("{\"id\":22214,\"displayName\":\"Test\"}", MediaType.APPLICATION_JSON));
+
+        TradeOrder submitted = controller.createTradeOrder(order(), "user01").getBody();
+
+        assertNotNull(submitted.getCorrelationId());
+        assertEquals(DecisionReason.VALIDATED, capturedReason(DecisionOutcome.ACCEPTED));
+        verify(publisher).publish(eq("/trades"), any(TradeOrder.class));
+    }
+
+    @Test
+    void anUnknownSecurityIsAuditedAsRejected() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.SECURITY_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anUnknownAccountIsAuditedAsRejected() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anOrderRefusedBecauseAValidationServiceFailedIsStillAudited() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM")).andRespond(withServerError());
+
+        assertThrows(RuntimeException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.VALIDATION_UNAVAILABLE, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anOverlongSubmittingUserIsTruncatedToTheAuditColumnWidth() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.createTradeOrder(order(), "u".repeat(200)));
+
+        ArgumentCaptor<String> submittedBy = ArgumentCaptor.forClass(String.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
+                any(DecisionReason.class), submittedBy.capture());
+        assertEquals(50, submittedBy.getValue().length());
+    }
+
+    @Test
+    void anAnonymousSubmissionIsRecordedAsUnknownRatherThanNotAtAll() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), null));
+
+        ArgumentCaptor<String> submittedBy = ArgumentCaptor.forClass(String.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
+                any(DecisionReason.class), submittedBy.capture());
+        assertEquals("UNKNOWN", submittedBy.getValue());
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -85,6 +85,27 @@ class TradeOrderControllerAuditTest {
     }
 
     @Test
+    void anOrderMissingASecurityIsAuditedAsInvalidWithoutCallingAnyLookupService() {
+        TradeOrder incomplete = new TradeOrder("ORDER-1", 22214, null, TradeSide.Buy, 100);
+
+        assertThrows(InvalidSubmissionException.class, () -> controller.createTradeOrder(incomplete, "user01"));
+
+        assertEquals(DecisionReason.SUBMISSION_INVALID, capturedReason(DecisionOutcome.REJECTED));
+        downstream.verify();
+    }
+
+    @Test
+    void anOrderMissingAnAccountIsAuditedAsInvalidWithoutCallingAnyLookupService() {
+        TradeOrder incomplete = order();
+        ReflectionTestUtils.setField(incomplete, "accountId", null);
+
+        assertThrows(InvalidSubmissionException.class, () -> controller.createTradeOrder(incomplete, "user01"));
+
+        assertEquals(DecisionReason.SUBMISSION_INVALID, capturedReason(DecisionOutcome.REJECTED));
+        downstream.verify();
+    }
+
+    @Test
     void anUnknownSecurityIsAuditedAsRejected() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
                 .andRespond(withStatus(HttpStatus.NOT_FOUND));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -122,6 +122,16 @@ class TradeOrderControllerAuditTest {
     }
 
     @Test
+    void anOrderWithANonPositiveQuantityIsAuditedAsInvalidRatherThanAcceptedAndLeftUnbooked() {
+        TradeOrder zeroQuantity = new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 0);
+
+        assertThrows(InvalidSubmissionException.class, () -> controller.createTradeOrder(zeroQuantity, "user01"));
+
+        assertEquals(DecisionReason.SUBMISSION_INVALID, capturedReason(DecisionOutcome.REJECTED));
+        downstream.verify();
+    }
+
+    @Test
     void anUnknownSecurityIsAuditedAsRejected() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
                 .andRespond(withStatus(HttpStatus.NOT_FOUND));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -137,17 +137,13 @@ class TradeOrderControllerAuditTest {
     }
 
     @Test
-    void anOverlongSubmittingUserIsTruncatedToTheAuditColumnWidth() {
+    void anEmptyBodyFromALookupServiceIsNotTreatedAsAValidatedSecurity() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
-                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+                .andRespond(withSuccess());
 
-        assertThrows(ResourceNotFoundException.class,
-                () -> controller.createTradeOrder(order(), "u".repeat(200)));
+        assertThrows(ValidationUnavailableException.class, () -> controller.createTradeOrder(order(), "user01"));
 
-        ArgumentCaptor<String> submittedBy = ArgumentCaptor.forClass(String.class);
-        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
-                any(DecisionReason.class), submittedBy.capture());
-        assertEquals(50, submittedBy.getValue().length());
+        assertEquals(DecisionReason.VALIDATION_UNAVAILABLE, capturedReason(DecisionOutcome.REJECTED));
     }
 
     @Test
@@ -161,15 +157,15 @@ class TradeOrderControllerAuditTest {
     }
 
     @Test
-    void anEmptyBodyFromALookupServiceDoesNotEscapeTheAuditPath() {
+    void anEmptyBodyFromTheAccountServiceIsNotTreatedAsAValidatedAccount() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
-                .andRespond(withSuccess());
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
         downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
-                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+                .andRespond(withSuccess());
 
-        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+        assertThrows(ValidationUnavailableException.class, () -> controller.createTradeOrder(order(), "user01"));
 
-        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
+        assertEquals(DecisionReason.VALIDATION_UNAVAILABLE, capturedReason(DecisionOutcome.REJECTED));
     }
 
     @Test

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -132,6 +132,16 @@ class TradeOrderControllerAuditTest {
     }
 
     @Test
+    void anOrderWithNoSideIsRejectedRatherThanBookedAsASale() {
+        TradeOrder noSide = new TradeOrder("ORDER-1", 22214, "IBM", null, 100);
+
+        assertThrows(InvalidSubmissionException.class, () -> controller.createTradeOrder(noSide, "user01"));
+
+        assertEquals(DecisionReason.SUBMISSION_INVALID, capturedReason(DecisionOutcome.REJECTED));
+        downstream.verify();
+    }
+
+    @Test
     void anUnknownSecurityIsAuditedAsRejected() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
                 .andRespond(withStatus(HttpStatus.NOT_FOUND));

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.client.RestTemplate;
 import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
+import finos.traderx.tradeservice.exceptions.ValidationUnavailableException;
 import finos.traderx.tradeservice.model.TradeOrder;
 import finos.traderx.tradeservice.model.TradeSide;
 import finos.traderx.tradeservice.model.audit.DecisionOutcome;
@@ -108,7 +109,7 @@ class TradeOrderControllerAuditTest {
     void anOrderRefusedBecauseAValidationServiceFailedIsStillAudited() {
         downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM")).andRespond(withServerError());
 
-        assertThrows(RuntimeException.class, () -> controller.createTradeOrder(order(), "user01"));
+        assertThrows(ValidationUnavailableException.class, () -> controller.createTradeOrder(order(), "user01"));
 
         assertEquals(DecisionReason.VALIDATION_UNAVAILABLE, capturedReason(DecisionOutcome.REJECTED));
     }
@@ -125,6 +126,18 @@ class TradeOrderControllerAuditTest {
         verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
                 any(DecisionReason.class), submittedBy.capture());
         assertEquals(50, submittedBy.getValue().length());
+    }
+
+    @Test
+    void anEmptyBodyFromALookupServiceDoesNotEscapeTheAuditPath() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess());
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
     }
 
     @Test

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -22,6 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import finos.traderx.messaging.PubSubException;
 import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
 import finos.traderx.tradeservice.exceptions.InvalidSubmissionException;
@@ -82,6 +84,20 @@ class TradeOrderControllerAuditTest {
         assertNotNull(submitted.getCorrelationId());
         assertEquals(DecisionReason.VALIDATED, capturedReason(DecisionOutcome.ACCEPTED));
         verify(publisher).publish(eq("/trades"), any(TradeOrder.class));
+    }
+
+    @Test
+    void anOrderThatCannotBeHandedToTheFeedGetsASecondRecordSayingSo() throws Exception {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withSuccess("{\"id\":22214,\"displayName\":\"Test\"}", MediaType.APPLICATION_JSON));
+        doThrow(new PubSubException("feed down")).when(publisher).publish(eq("/trades"), any(TradeOrder.class));
+
+        assertThrows(RuntimeException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.VALIDATED, capturedReason(DecisionOutcome.ACCEPTED));
+        assertEquals(DecisionReason.DISPATCH_FAILED, capturedReason(DecisionOutcome.REJECTED));
     }
 
     @Test

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -24,6 +24,7 @@ import org.springframework.web.client.RestTemplate;
 
 import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
+import finos.traderx.tradeservice.exceptions.InvalidSubmissionException;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
 import finos.traderx.tradeservice.exceptions.ValidationUnavailableException;
 import finos.traderx.tradeservice.model.TradeOrder;
@@ -126,6 +127,16 @@ class TradeOrderControllerAuditTest {
         verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
                 any(DecisionReason.class), submittedBy.capture());
         assertEquals(50, submittedBy.getValue().length());
+    }
+
+    @Test
+    void aLookupServiceRejectingTheRequestIsAuditedAsABadSubmissionNotAnOutage() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+        assertThrows(InvalidSubmissionException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.SUBMISSION_INVALID, capturedReason(DecisionOutcome.REJECTED));
     }
 
     @Test

--- a/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
@@ -42,7 +42,7 @@ class OrderDecisionAuditRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        List<OrderDecisionAudit> found = repository.findByCorrelationId("CORR-A");
+        List<OrderDecisionAudit> found = repository.findByCorrelationIdOrderByDecisionTimestampAsc("CORR-A");
 
         assertEquals(1, found.size());
         assertEquals(DecisionOutcome.REJECTED, found.get(0).getDecision());

--- a/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
@@ -49,7 +49,7 @@ class OrderDecisionAuditRepositoryTest {
         entityManager.clear();
 
         List<OrderDecisionAudit> found = repository
-                .findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc("CORR-A");
+                .findByCorrelationIdOrderByRecordedAtAsc("CORR-A");
 
         assertEquals(1, found.size());
         assertEquals(DecisionOutcome.REJECTED, found.get(0).getDecision());
@@ -67,7 +67,7 @@ class OrderDecisionAuditRepositoryTest {
         entityManager.clear();
 
         List<OrderDecisionAudit> found = repository
-                .findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc("CORR-C");
+                .findByCorrelationIdOrderByRecordedAtAsc("CORR-C");
 
         assertEquals(List.of(DecisionReason.VALIDATED, DecisionReason.DISPATCH_FAILED),
                 found.stream().map(OrderDecisionAudit::getReasonCode).toList());

--- a/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
@@ -1,0 +1,67 @@
+package finos.traderx.tradeservice.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.EvaluatedLimit;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+
+@DataJpaTest
+class OrderDecisionAuditRepositoryTest {
+
+    @Autowired
+    private OrderDecisionAuditRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private OrderDecisionAudit rejectedRecord(String id, String correlationId) {
+        return new OrderDecisionAudit(id, correlationId, "ORDER-" + id, 22214, "IBM", "Buy", 100,
+                new BigDecimal("10.0000"), "CONFIGURED_STATIC_REFERENCE_PRICE", new BigDecimal("1000.0000"),
+                DecisionOutcome.REJECTED, DecisionReason.SECURITY_NOT_FOUND,
+                new EvaluatedLimit("DEFAULT-ACCOUNT-NOTIONAL", "ACCOUNT_NOTIONAL", new BigDecimal("5000000.0000"),
+                        Instant.parse("2024-01-01T00:00:00Z")),
+                "user01", Instant.parse("2026-08-12T09:15:30.123Z"));
+    }
+
+    @Test
+    void persistsAndRetrievesADecisionByCorrelationId() {
+        repository.save(rejectedRecord("A1", "CORR-A"));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<OrderDecisionAudit> found = repository.findByCorrelationId("CORR-A");
+
+        assertEquals(1, found.size());
+        assertEquals(DecisionOutcome.REJECTED, found.get(0).getDecision());
+        assertEquals(Instant.parse("2026-08-12T09:15:30.123Z"), found.get(0).getDecisionTimestamp());
+    }
+
+    @Test
+    void aPersistedDecisionCannotBeUpdated() throws Exception {
+        OrderDecisionAudit saved = repository.save(rejectedRecord("A2", "CORR-B"));
+        entityManager.flush();
+
+        Field decision = OrderDecisionAudit.class.getDeclaredField("decision");
+        decision.setAccessible(true);
+        decision.set(saved, DecisionOutcome.ACCEPTED);
+        entityManager.flush();
+        entityManager.clear();
+
+        OrderDecisionAudit reloaded = repository.findById("A2").orElseThrow();
+        assertEquals(DecisionOutcome.REJECTED, reloaded.getDecision());
+        assertTrue(reloaded.isNew());
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
@@ -28,12 +28,18 @@ class OrderDecisionAuditRepositoryTest {
     private TestEntityManager entityManager;
 
     private OrderDecisionAudit rejectedRecord(String id, String correlationId) {
+        return record(id, correlationId, DecisionOutcome.REJECTED, DecisionReason.SECURITY_NOT_FOUND,
+                Instant.parse("2026-08-12T09:15:30.123456Z"));
+    }
+
+    private OrderDecisionAudit record(String id, String correlationId, DecisionOutcome decision,
+            DecisionReason reason, Instant recordedAt) {
         return new OrderDecisionAudit(id, correlationId, "ORDER-" + id, 22214, "IBM", "Buy", 100,
                 new BigDecimal("10.0000"), "CONFIGURED_STATIC_REFERENCE_PRICE", new BigDecimal("1000.0000"),
-                DecisionOutcome.REJECTED, DecisionReason.SECURITY_NOT_FOUND,
+                decision, reason,
                 new EvaluatedLimit("DEFAULT-ACCOUNT-NOTIONAL", "ACCOUNT_NOTIONAL", new BigDecimal("5000000.0000"),
                         Instant.parse("2024-01-01T00:00:00Z")),
-                "user01", Instant.parse("2026-08-12T09:15:30.123Z"));
+                "user01", Instant.parse("2026-08-12T09:15:30.123Z"), recordedAt);
     }
 
     @Test
@@ -42,11 +48,29 @@ class OrderDecisionAuditRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        List<OrderDecisionAudit> found = repository.findByCorrelationIdOrderByDecisionTimestampAsc("CORR-A");
+        List<OrderDecisionAudit> found = repository
+                .findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc("CORR-A");
 
         assertEquals(1, found.size());
         assertEquals(DecisionOutcome.REJECTED, found.get(0).getDecision());
         assertEquals(Instant.parse("2026-08-12T09:15:30.123Z"), found.get(0).getDecisionTimestamp());
+    }
+
+    @Test
+    void twoRecordsInTheSameMillisecondAreReturnedInTheOrderTheyWereWritten() {
+        // Saved failure-first so a database returning insertion order would not accidentally pass.
+        repository.save(record("A4", "CORR-C", DecisionOutcome.REJECTED, DecisionReason.DISPATCH_FAILED,
+                Instant.parse("2026-08-12T09:15:30.123456Z")));
+        repository.save(record("A3", "CORR-C", DecisionOutcome.ACCEPTED, DecisionReason.VALIDATED,
+                Instant.parse("2026-08-12T09:15:30.123001Z")));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<OrderDecisionAudit> found = repository
+                .findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc("CORR-C");
+
+        assertEquals(List.of(DecisionReason.VALIDATED, DecisionReason.DISPATCH_FAILED),
+                found.stream().map(OrderDecisionAudit::getReasonCode).toList());
     }
 
     @Test


### PR DESCRIPTION
## Summary

**TRX-104.** Today TraderX keeps no record of an order that was rejected — the order simply never exists. Under MiFID II Art. 16(6) and the RTS 27/28 best-execution regime, the firm has to be able to reconstruct, five years later, *why* any given order was accepted **or rejected**, and to do so against the limit that was in force at the time, not the limit as it stands today. The interesting record is the one for the order that didn't happen, and we currently destroy it.

This PR adds an append-only `OrderDecisionAudit` record written for **every** submission to `POST /trade/`, accepted or rejected, and threads a correlation id from that decision through the trade feed onto the booked trade so the record can be tied to what was actually executed.

What the record holds: order id, account, security, side, quantity, the price used and its provenance, computed notional, `ACCEPTED`/`REJECTED` plus a machine-readable reason code, a **by-value snapshot** of the limit evaluated (`limitId`, `limitType`, `limitValue`, `limitEffectiveFrom`) so the decision stays reconstructable after that limit is later amended, the submitting user, and a UTC timestamp truncated to milliseconds.

Append-only is enforced in four places rather than asserted in a comment:

```java
@Entity @Immutable                                  // Hibernate never emits UPDATE
public class OrderDecisionAudit implements Persistable<String> {
    @Column(updatable = false) ...                  // every column, no exceptions
    public boolean isNew() { return true; }         // save() is INSERT, never merge
    // ... getters only, no setters
}

// extends Repository, NOT JpaRepository/CrudRepository — inheriting those would
// hand every caller delete(), deleteAll() and friends.
interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
    OrderDecisionAudit save(...); Optional<...> findById(...);
    List<...> findByCorrelationId(...); List<...> findByAccountId(...);
}
```

A test asserts by reflection that the entity declares no `set*` method and the repository declares no delete/remove method, so a future edit that reopens a mutation path fails the build rather than the audit.

Control flow in `TradeOrderController` — the happy path and the two 404s behave exactly as before:

```java
correlationId = UUID.randomUUID(); tradeOrder.setCorrelationId(correlationId);
// "does not exist", "bad question" and "could not ask" are different facts,
// and a record is written on every one of them
tickerLookup == UNAVAILABLE        -> { audit(REJECTED, VALIDATION_UNAVAILABLE); throw ValidationUnavailable; }
tickerLookup == INVALID_SUBMISSION -> { audit(REJECTED, SUBMISSION_INVALID);     throw InvalidSubmission; }
tickerLookup == NOT_FOUND          -> { audit(REJECTED, SECURITY_NOT_FOUND);      throw ResourceNotFound; }
// ... same shape for the account lookup, with ACCOUNT_NOT_FOUND
audit(ACCEPTED, VALIDATED); tradePublisher.publish("/trades", tradeOrder);
```

Every exit path from the endpoint writes exactly one record, including the ones where a lookup could not be performed at all — an order refused because we could not check it is still an order that was refused.

That forces the error paths to be told apart, since the record must not misstate *why* an order was refused. A lookup previously returned a bare boolean, so "does not exist", "you asked a bad question" and "the service is down" were all filed as `404 not found`:

| Outcome | Reason code | Status |
| --- | --- | --- |
| missing security or account id on the submission | `SUBMISSION_INVALID` | 400 (no lookup performed) |
| 404 from the lookup service | `SECURITY_NOT_FOUND` / `ACCOUNT_NOT_FOUND` | 404 (unchanged) |
| 400/422 — the service objected to the request | `SUBMISSION_INVALID` | 400 |
| 401/403/429, 5xx, timeout, connection refused, empty 2xx body | `VALIDATION_UNAVAILABLE` | 503 |
| validated, but the trade feed could not be reached | `DISPATCH_FAILED`, appended after the `ACCEPTED` record | 500 |

Missing security, missing account, missing side and non-positive quantity are refused before any lookup, on one rule: the trail must not record an acceptance the booking cannot honour. A non-positive quantity fails `Trades`' `check Quantity > 0`; a missing side is worse, because it does not fail — `trade-processor` treats anything that is not `Buy` as a sell, and a CHECK constraint passes on NULL, so the position would have been reduced under a record saying `VALIDATED`.

Bound on the `DISPATCH_FAILED` guarantee: it covers exceptions that escape the publisher. The wired `SocketIOJSONPublisher` throws only when disconnected and otherwise swallows serialize/emit errors internally (pre-existing, in the shared messaging layer), so a failure inside a connected publish still leaves an `ACCEPTED` record with no counterpart. Closing that means either changing the shared publisher or an outbox — both larger than this ticket.

An expired credential or a rate limit is our availability problem, not the trader's, so it must not be recorded as a bad order.

The two new statuses are a deliberate behaviour change on error paths that previously returned 404.

Schema is additive: new `OrderDecisionAudit` table plus a nullable `CorrelationID` column on `Trades`. The audit table deliberately has **no** foreign key to `Accounts` — a rejected order may name an account that does not exist, and that rejection still has to be storable.

- **No new runtime dependency.** JPA, H2 and Hibernate were already on both services' classpaths.
- **Feature flag:** `audit.best-execution.enabled` (`BEST_EXECUTION_AUDIT_ENABLED`), default **on** in dev. Limit values, effective-from and the reference price are externalised in `application.properties`, not hard-coded.
- **Bounded lookups:** the `RestTemplate` now carries explicit connect/read timeouts (`LOOKUP_CONNECT_TIMEOUT_MS`, `LOOKUP_READ_TIMEOUT_MS`). Without them a hung validation service leaves a submission pending with no decision reached, and therefore nothing recorded — the one outcome an audit trail cannot represent.
- `./gradlew build` passes for `trade-service` and `trade-processor`; 32 new tests cover an accepted decision, each rejection reason, the flag being off, immutability (by reflection *and* by a real flush/reload against H2), and correlation through to booking.

## Decisions and open questions

The ticket flagged two trade-offs deliberately, and implementing it surfaced three more. Below is what I chose and why; the starred ones I do not think an agent should close on its own.

**Decided — synchronous audit write, not published to the bus.** The record commits in its own transaction (`REQUIRES_NEW`) *before* the order is published to `trade-feed`. Cost: one extra DB round-trip on the submission path. Benefit: the record cannot be lost by a socket.io drop, and it survives a later failure in the same request. For a regulatory record that must be produced on demand five years later, a best-effort transport is not a defensible substitute for a committed row — a dropped message is indistinguishable from an order that was never submitted, which is exactly the gap this ticket exists to close. If submission latency later proves to matter, the right answer is a durable outbox in the same transaction, not a fire-and-forget publish.

Committing before publishing does mean the accepted record can outlive the hand-off, so a failure to reach the feed appends a second record (`REJECTED` / `DISPATCH_FAILED`) under the same correlation id rather than amending the first. Both stand: the decision was to accept, and the order then did not go out — a correction in an append-only trail is a new fact, not an edit. An outbox would still be stronger, since it also covers the process dying between the two writes; that remains a follow-up.

Because both records can land in the same millisecond, the table carries a separate `RecordedAt TIMESTAMP(6)` used purely as the ordering key. `DecisionTimestamp` stays truncated to milliseconds as the ticket specifies; `RecordedAt` is strictly increasing within the process that wrote the pair, so `findByCorrelationIdOrderByDecisionTimestampAscRecordedAtAsc` reads back accept-then-failure rather than an arbitrary order. Note for TRX-105: the later record does not supersede the earlier one — both are true, and last-write-wins is the wrong reading of an append-only trail.

**Decided — five-year retention is raised here, not built here.** No retention or archival mechanism is in this PR. Retention on an append-only table is a storage, backup and legal-hold concern (WORM storage, restricted DB grants, an archival job with a documented destruction schedule) and none of it belongs in application code. What application code *can* guarantee — that nothing in the service will ever mutate or delete a record — is what this PR delivers. **Follow-up ticket needed:** retention policy, backup/restore evidence, and revoking `UPDATE`/`DELETE` on this table from the service's DB role.

One retention-shaped thing *is* fixed here, because it would have made the demo untrue: `initialSchema.sql` re-runs on every database start and drops every table it owns. `OrderDecisionAudit` is the one exception — no `DROP`, `CREATE TABLE IF NOT EXISTS` — so it accumulates while the seeded demo tables are rebuilt. A retained record that a restart erases is not a retained record. Scope of that claim: the H2 files live inside the container, so the trail survives a database restart but not a rebuild.

**★ Decided provisionally — the "limit evaluated" is a configured placeholder.** TRX-102 (limits store) and TRX-101 (enforcement) are not merged, so there is no real limit to evaluate. Rather than block, this PR records a limit snapshot sourced from configuration, with the same shape the real one will have, and **does not enforce it** — enforcement is TRX-101's scope and this PR changes no accept/reject outcome. When TRX-102 lands, `BestExecutionAuditProperties.Limit` should be replaced by a lookup against the limits store; the audit columns do not change. **Needs a human:** confirm that recording a placeholder limit is acceptable in the interim, or whether the audit trail should only go live once real limits exist.

**★ Decided provisionally — the price is a configured reference price.** TraderX has no market data service; `reference-data` serves tickers and company names only. Notional is `quantity × configured reference price`, and every record carries `priceSource = CONFIGURED_STATIC_REFERENCE_PRICE` so the record is honest about its own provenance rather than silently implying a real execution price. **Needs a human:** RTS 27/28 best-execution evidence ultimately requires a real venue/benchmark price with its own timestamp. Which price — arrival price, venue mid, last traded — is a compliance decision, not an engineering one.

**★ Decided provisionally — submitting user comes from an optional `X-TraderX-User` header,** defaulting to `UNKNOWN`. TraderX has no authentication, and the request body carries no user. The header keeps the change additive and the existing front-ends working untouched. **Needs a human:** an audit record whose "who" field can be set by the caller and defaults to `UNKNOWN` is not defensible under Art. 16(6) in production. The identity must come from an authenticated principal, which TraderX does not have.

**Scope of the kill switch:** `audit.best-execution.enabled=false` stops records being written, but does not remove trade-service's new startup dependency on the shared database — JPA autoconfiguration is unconditional. A true rollback lever would need a profile that excludes JPA entirely, which is worth deciding explicitly rather than inferring here.

**Rollout constraint:** `trade-processor` must be deployed before `trade-service`. The published `TradeOrder` now carries `correlationId`, and the feed subscriber's `ObjectMapper` rejects unknown properties, so an old processor would silently drop new orders. Both services ship in this PR, so a single rollout is unaffected. Making the subscriber lenient would change how every message in the system is parsed, which is not a call to make inside an audit ticket.

**Minor, decided:** `trade-service` now points at the shared TraderX H2 database (it already had JPA and H2 on the classpath and already received `DATABASE_TCP_HOST` in `docker-compose.yml`, but no datasource configuration, so it was silently using a service-local embedded DB). The audit trail belongs next to the trades it explains, and TRX-105's query API will read it from there. Side effect worth naming on screen: `trade-service` now genuinely depends on the database being up.


Link to Devin session: https://app.devin.ai/sessions/9dad0bc4c57d4c3bbea2212335a1d017
Requested by: @chrischappell-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/99?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/traderxcognitiondemos/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->