### PR TITLE
TRX-105: Audit query API + "Compliance" tab on the blotter

### DIFF
--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -55,6 +55,15 @@ CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (Correlati
 
 CREATE INDEX IDX_OrderDecisionAudit_Account_Time ON OrderDecisionAudit (AccountID, DecisionTimestamp);
 
+-- Indexes below back the compliance query API (TRX-105). Every supported filter combination
+-- is anchored on DecisionTimestamp because the table is retained for five years and is always
+-- read as "this filter, over this window, newest first" - never as an unbounded scan.
+CREATE INDEX IDX_OrderDecisionAudit_Time ON OrderDecisionAudit (DecisionTimestamp, ID);
+
+CREATE INDEX IDX_OrderDecisionAudit_Security_Time ON OrderDecisionAudit (Security, DecisionTimestamp);
+
+CREATE INDEX IDX_OrderDecisionAudit_Decision_Time ON OrderDecisionAudit (Decision, DecisionTimestamp);
+
 CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 
 --- SAMPLE DATA ---

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -44,9 +44,11 @@ CREATE TABLE OrderDecisionAudit (
   LimitID VARCHAR(40),
   LimitType VARCHAR(40),
   LimitValue DECIMAL(23,4),
-  LimitEffectiveFrom TIMESTAMP(3),
+  LimitEffectiveFrom TIMESTAMP(3) WITH TIME ZONE,
   SubmittedBy VARCHAR(50),
-  DecisionTimestamp TIMESTAMP(3) NOT NULL
+  -- WITH TIME ZONE so external readers (TRX-105, exports) see UTC rather than the
+  -- session wall clock; Hibernate maps java.time.Instant to TIMESTAMP_UTC.
+  DecisionTimestamp TIMESTAMP(3) WITH TIME ZONE NOT NULL
 );
 
 CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -1,3 +1,5 @@
+Drop Table OrderDecisionAudit IF EXISTS;
+
 Drop Table Trades IF EXISTS;
 
 Drop Table AccountUsers IF EXISTS; 
@@ -18,9 +20,38 @@ CREATE TABLE Positions ( AccountID INTEGER , Security VARCHAR(15) , Updated TIME
 
 Alter Table Positions ADD FOREIGN KEY (AccountID) References Accounts(ID) ; 
 
-CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TIMESTAMP, Updated TIMESTAMP, Security VARCHAR (15) ,  Side VARCHAR(10) check (Side in ('Buy','Sell')),  Quantity INTEGER check Quantity > 0 , State VARCHAR(20) check (State in ('New', 'Processing', 'Settled', 'Cancelled'))) ;  
+CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TIMESTAMP, Updated TIMESTAMP, Security VARCHAR (15) ,  Side VARCHAR(10) check (Side in ('Buy','Sell')),  Quantity INTEGER check Quantity > 0 , State VARCHAR(20) check (State in ('New', 'Processing', 'Settled', 'Cancelled')), CorrelationID VARCHAR(50)) ;  
 
 Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID); 
+
+-- MiFID II Art. 16(6) / RTS 27-28 best-execution record. Append-only: written once by
+-- trade-service for every submission, accepted or rejected, and never updated or deleted.
+-- Deliberately has no foreign key to Accounts, because a rejected order may name an account
+-- that does not exist - that rejection still has to be reconstructable.
+CREATE TABLE OrderDecisionAudit (
+  ID VARCHAR(50) PRIMARY KEY,
+  CorrelationID VARCHAR(50) NOT NULL,
+  OrderID VARCHAR(50),
+  AccountID INTEGER,
+  Security VARCHAR(50),
+  Side VARCHAR(10),
+  Quantity INTEGER,
+  Price DECIMAL(19,4),
+  PriceSource VARCHAR(40),
+  Notional DECIMAL(23,4),
+  Decision VARCHAR(10) NOT NULL check (Decision in ('ACCEPTED','REJECTED')),
+  ReasonCode VARCHAR(40) NOT NULL,
+  LimitID VARCHAR(40),
+  LimitType VARCHAR(40),
+  LimitValue DECIMAL(23,4),
+  LimitEffectiveFrom TIMESTAMP(3),
+  SubmittedBy VARCHAR(50),
+  DecisionTimestamp TIMESTAMP(3) NOT NULL
+);
+
+CREATE INDEX IDX_OrderDecisionAudit_Correlation ON OrderDecisionAudit (CorrelationID);
+
+CREATE INDEX IDX_OrderDecisionAudit_Account_Time ON OrderDecisionAudit (AccountID, DecisionTimestamp);
 
 CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 

--- a/position-service/openapi.yaml
+++ b/position-service/openapi.yaml
@@ -144,11 +144,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditPage'
         '400':
-          description: Unknown decision value, negative page, or 'to' before 'from'
+          description: Unknown decision value, unreadable filter, negative page, or 'to' before 'from'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Query failed; detail is logged, not returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '503':
           description: Audit query API disabled by configuration
 components:
   schemas:
+    ApiError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Unknown 'decision' filter. Expected one of [ACCEPTED, REJECTED]"
     Trade:
       type: object
       properties:

--- a/position-service/openapi.yaml
+++ b/position-service/openapi.yaml
@@ -77,6 +77,74 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Position'
+  /audit/decisions:
+    get:
+      tags:
+        - audit-controller
+      summary: Query the best-execution audit trail
+      description: >-
+        Read-only, paged query over the immutable order decision records retained under
+        MiFID II Art. 16(6) and RTS 27/28. Newest decision first. There is no mutation
+        endpoint on this resource by design.
+      operationId: getDecisions
+      parameters:
+        - name: accountId
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: security
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: decision
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ACCEPTED, REJECTED]
+        - name: from
+          in: query
+          description: Inclusive lower bound on decisionTimestamp, ISO-8601 instant.
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: Exclusive upper bound on decisionTimestamp, ISO-8601 instant.
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          description: Clamped to audit.query.max-page-size.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 50
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditPage'
+        '400':
+          description: Unknown decision value, negative page, or 'to' before 'from'
+        '503':
+          description: Audit query API disabled by configuration
 components:
   schemas:
     Trade:
@@ -126,3 +194,70 @@ components:
           type: string
           format: date-time
           example: '2020-01-01T00:00:00.000Z'
+    AuditPage:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderDecision'
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    OrderDecision:
+      type: object
+      properties:
+        id:
+          type: string
+        correlationId:
+          type: string
+        orderId:
+          type: string
+        accountId:
+          type: integer
+          format: int32
+          example: 22214
+        security:
+          type: string
+          example: 'ADBE'
+        side:
+          type: string
+          example: 'Buy'
+        quantity:
+          type: integer
+          format: int32
+        price:
+          type: number
+        priceSource:
+          type: string
+        notional:
+          type: number
+        decision:
+          type: string
+          enum: [ACCEPTED, REJECTED]
+        reasonCode:
+          type: string
+          example: 'ACCOUNT_LIMIT_BREACHED'
+        limitId:
+          type: string
+        limitType:
+          type: string
+        limitValue:
+          type: number
+        limitEffectiveFrom:
+          type: string
+          format: date-time
+        submittedBy:
+          type: string
+        decisionTimestamp:
+          type: string
+          format: date-time

--- a/position-service/openapi.yaml
+++ b/position-service/openapi.yaml
@@ -97,8 +97,10 @@ paths:
         - name: security
           in: query
           required: false
+          description: Ticker, matched case-insensitively and trimmed.
           schema:
             type: string
+            example: 'AAPL'
         - name: decision
           in: query
           required: false

--- a/position-service/openapi.yaml
+++ b/position-service/openapi.yaml
@@ -109,14 +109,18 @@ paths:
             enum: [ACCEPTED, REJECTED]
         - name: from
           in: query
-          description: Inclusive lower bound on decisionTimestamp, ISO-8601 instant.
+          description: >-
+            Inclusive lower bound on decisionTimestamp. An offset is required,
+            e.g. 2026-01-01T00:00:00Z; a zone-less value is answered with 400.
           required: false
           schema:
             type: string
             format: date-time
         - name: to
           in: query
-          description: Exclusive upper bound on decisionTimestamp, ISO-8601 instant.
+          description: >-
+            Exclusive upper bound on decisionTimestamp. An offset is required,
+            e.g. 2026-04-01T00:00:00Z; a zone-less value is answered with 400.
           required: false
           schema:
             type: string

--- a/position-service/src/main/java/finos/traderx/positionservice/audit/AuditConfig.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/audit/AuditConfig.java
@@ -1,0 +1,9 @@
+package finos.traderx.positionservice.audit;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuditQueryProperties.class)
+public class AuditConfig {
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/audit/AuditQueryProperties.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/audit/AuditQueryProperties.java
@@ -1,0 +1,44 @@
+package finos.traderx.positionservice.audit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Externalised configuration for the compliance query API (TRX-105).
+ *
+ * {@code enabled} is the single kill switch for the whole feature, on by default in dev. The
+ * page sizes are configuration rather than constants because the sensible ceiling depends on
+ * how much history a deployment actually holds.
+ */
+@ConfigurationProperties(prefix = "audit.query")
+public class AuditQueryProperties {
+
+    private boolean enabled = true;
+
+    private int defaultPageSize = 50;
+
+    private int maxPageSize = 500;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getDefaultPageSize() {
+        return defaultPageSize;
+    }
+
+    public void setDefaultPageSize(int defaultPageSize) {
+        this.defaultPageSize = defaultPageSize;
+    }
+
+    public int getMaxPageSize() {
+        return maxPageSize;
+    }
+
+    public void setMaxPageSize(int maxPageSize) {
+        this.maxPageSize = maxPageSize;
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Locale;
 
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -68,6 +69,16 @@ public class AuditController {
             throw new IllegalArgumentException(
                     "Unknown decision '" + decision + "'. Expected one of " + Arrays.toString(DecisionOutcome.values()));
         }
+    }
+
+    /**
+     * A filter the caller mistyped is a bad request, not an outage. Without this the controller's
+     * catch-all would turn Spring's binding failure into a 500 and the Compliance tab would
+     * report the audit trail as unavailable.
+     */
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<String> typeMismatch(TypeMismatchException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Locale;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -30,6 +32,8 @@ import finos.traderx.positionservice.service.AuditQueryService;
 @RestController
 @RequestMapping(value = "/audit", produces = "application/json")
 public class AuditController {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditController.class);
 
     private final AuditQueryService auditQueryService;
 
@@ -86,8 +90,13 @@ public class AuditController {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
+    /**
+     * The failure is logged, not returned. A persistence error's message carries schema and query
+     * detail, and this endpoint answers anyone who can reach the service.
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> generalError(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        log.error("Failed to query the order decision audit trail", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Could not query the audit trail.");
     }
 }

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import finos.traderx.positionservice.model.audit.AuditPage;
 import finos.traderx.positionservice.model.audit.DecisionOutcome;
 import finos.traderx.positionservice.service.AuditQueryService;
+import finos.traderx.positionservice.service.InvalidAuditQueryException;
 
 /**
  * Read-only query API over the best-execution audit trail written by trade-service (TRX-104),
@@ -70,7 +71,7 @@ public class AuditController {
         try {
             return DecisionOutcome.valueOf(decision.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
+            throw new InvalidAuditQueryException(
                     "Unknown 'decision' filter. Expected one of " + Arrays.toString(DecisionOutcome.values()));
         }
     }
@@ -86,8 +87,13 @@ public class AuditController {
         return badRequest("Could not read the '" + e.getPropertyName() + "' filter.");
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiError> badRequest(IllegalArgumentException e) {
+    /**
+     * Only this type is answered with its own message. An {@code IllegalArgumentException} from
+     * below the service belongs to the caller-facing catch-all: its message carries query and
+     * mapping detail, and it is a fault here rather than a bad request.
+     */
+    @ExceptionHandler(InvalidAuditQueryException.class)
+    public ResponseEntity<ApiError> invalidQuery(InvalidAuditQueryException e) {
         return badRequest(e.getMessage());
     }
 

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -71,23 +71,28 @@ public class AuditController {
             return DecisionOutcome.valueOf(decision.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
-                    "Unknown decision '" + decision + "'. Expected one of " + Arrays.toString(DecisionOutcome.values()));
+                    "Unknown 'decision' filter. Expected one of " + Arrays.toString(DecisionOutcome.values()));
         }
     }
 
     /**
      * A filter the caller mistyped is a bad request, not an outage. Without this the controller's
      * catch-all would turn Spring's binding failure into a 500 and the Compliance tab would
-     * report the audit trail as unavailable.
+     * report the audit trail as unavailable. Only the parameter name is echoed; the value came
+     * from the caller and Spring's message carries the internal type it failed to bind to.
      */
     @ExceptionHandler(TypeMismatchException.class)
-    public ResponseEntity<String> typeMismatch(TypeMismatchException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    public ResponseEntity<ApiError> typeMismatch(TypeMismatchException e) {
+        return badRequest("Could not read the '" + e.getPropertyName() + "' filter.");
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> badRequest(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    public ResponseEntity<ApiError> badRequest(IllegalArgumentException e) {
+        return badRequest(e.getMessage());
+    }
+
+    private ResponseEntity<ApiError> badRequest(String message) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiError(message));
     }
 
     /**
@@ -95,8 +100,17 @@ public class AuditController {
      * detail, and this endpoint answers anyone who can reach the service.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> generalError(Exception e) {
+    public ResponseEntity<ApiError> generalError(Exception e) {
         log.error("Failed to query the order decision audit trail", e);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Could not query the audit trail.");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiError("Could not query the audit trail."));
+    }
+
+    /**
+     * The endpoint declares {@code application/json}, so errors are JSON too. Messages are written
+     * here rather than lifted from the exception: neither the caller's own input nor Spring's
+     * internal property and type names belong in a response this endpoint hands to anyone.
+     */
+    public record ApiError(String message) {
     }
 }

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -1,0 +1,82 @@
+package finos.traderx.positionservice.controller;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import finos.traderx.positionservice.model.audit.AuditPage;
+import finos.traderx.positionservice.model.audit.DecisionOutcome;
+import finos.traderx.positionservice.service.AuditQueryService;
+
+/**
+ * Read-only query API over the best-execution audit trail written by trade-service (TRX-104),
+ * retained under MiFID II Art. 16(6) and RTS 27/28.
+ *
+ * There is deliberately no POST, PUT, PATCH or DELETE here, and there never should be. A record
+ * that can be amended after the fact is not evidence.
+ */
+@CrossOrigin("*")
+@RestController
+@RequestMapping(value = "/audit", produces = "application/json")
+public class AuditController {
+
+    private final AuditQueryService auditQueryService;
+
+    public AuditController(AuditQueryService auditQueryService) {
+        this.auditQueryService = auditQueryService;
+    }
+
+    @GetMapping("/decisions")
+    public ResponseEntity<AuditPage> getDecisions(
+            @RequestParam(required = false) Integer accountId,
+            @RequestParam(required = false) String security,
+            @RequestParam(required = false) String decision,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
+
+        if (!auditQueryService.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+        return ResponseEntity
+                .ok(auditQueryService.search(accountId, security, parseDecision(decision), from, to, page, size));
+    }
+
+    /**
+     * An unrecognised decision value is rejected rather than ignored. Silently dropping the
+     * filter would answer a narrow question with a wider result set, and a reviewer reading
+     * "rejected only" has no way to tell.
+     */
+    private DecisionOutcome parseDecision(String decision) {
+        if (decision == null || decision.isBlank()) {
+            return null;
+        }
+        try {
+            return DecisionOutcome.valueOf(decision.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Unknown decision '" + decision + "'. Expected one of " + Arrays.toString(DecisionOutcome.values()));
+        }
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> badRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> generalError(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/controller/AuditController.java
@@ -7,7 +7,6 @@ import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.TypeMismatchException;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -42,13 +41,19 @@ public class AuditController {
         this.auditQueryService = auditQueryService;
     }
 
+    /**
+     * {@code from} and {@code to} are parsed by Spring's instant converter, which requires an
+     * offset ({@code 2026-01-01T00:00:00Z}). A {@code @DateTimeFormat} annotation would not change
+     * that - the JSR-310 formatter factory does not cover {@code Instant} - so the requirement is
+     * documented in openapi.yaml instead of being annotated inertly.
+     */
     @GetMapping("/decisions")
     public ResponseEntity<AuditPage> getDecisions(
             @RequestParam(required = false) Integer accountId,
             @RequestParam(required = false) String security,
             @RequestParam(required = false) String decision,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
 

--- a/position-service/src/main/java/finos/traderx/positionservice/model/audit/AuditPage.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/model/audit/AuditPage.java
@@ -1,0 +1,22 @@
+package finos.traderx.positionservice.model.audit;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+/**
+ * Paged envelope for audit queries. Spring's own {@code Page} serialisation is deliberately not
+ * exposed on the wire: its JSON is unstable across Spring Data versions, and this response is
+ * read by the blotter and, in time, by regulatory exports.
+ */
+public record AuditPage(List<OrderDecisionView> content, int page, int size, long totalElements, int totalPages) {
+
+    public static AuditPage of(Page<OrderDecisionAudit> page) {
+        return new AuditPage(
+                page.getContent().stream().map(OrderDecisionView::of).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages());
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/model/audit/DecisionOutcome.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/model/audit/DecisionOutcome.java
@@ -1,0 +1,10 @@
+package finos.traderx.positionservice.model.audit;
+
+/**
+ * Mirrors the values written by trade-service (TRX-104). Persisted as a string in the
+ * retained record, so the names are part of the regulatory record and must not be renamed.
+ */
+public enum DecisionOutcome {
+    ACCEPTED,
+    REJECTED
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/model/audit/OrderDecisionAudit.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/model/audit/OrderDecisionAudit.java
@@ -1,0 +1,172 @@
+package finos.traderx.positionservice.model.audit;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Read-only projection of the best-execution audit record written by trade-service (TRX-104),
+ * retained under MiFID II Art. 16(6) and read here by the compliance query API.
+ *
+ * position-service owns no part of this table's lifecycle: it never inserts, updates or deletes
+ * a record. The mapping is therefore {@link Immutable}, declares every column
+ * {@code updatable = false} and exposes getters only, so an accidental mutation from the query
+ * side fails to compile rather than rewriting the record a regulator will later read.
+ *
+ * {@code reasonCode} is deliberately a String rather than an enum: trade-service may add a
+ * reason code without position-service being redeployed, and a reader that throws on an
+ * unrecognised value would hide exactly the decisions it is there to surface.
+ */
+@Entity
+@Immutable
+@Table(name = "ORDERDECISIONAUDIT")
+public class OrderDecisionAudit implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", length = 50, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "CORRELATIONID", length = 50, updatable = false, nullable = false)
+    private String correlationId;
+
+    @Column(name = "ORDERID", length = 50, updatable = false)
+    private String orderId;
+
+    @Column(name = "ACCOUNTID", updatable = false)
+    private Integer accountId;
+
+    @Column(name = "SECURITY", length = 50, updatable = false)
+    private String security;
+
+    @Column(name = "SIDE", length = 10, updatable = false)
+    private String side;
+
+    @Column(name = "QUANTITY", updatable = false)
+    private Integer quantity;
+
+    @Column(name = "PRICE", precision = 19, scale = 4, updatable = false)
+    private BigDecimal price;
+
+    @Column(name = "PRICESOURCE", length = 40, updatable = false)
+    private String priceSource;
+
+    @Column(name = "NOTIONAL", precision = 23, scale = 4, updatable = false)
+    private BigDecimal notional;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "DECISION", length = 10, updatable = false, nullable = false)
+    private DecisionOutcome decision;
+
+    @Column(name = "REASONCODE", length = 40, updatable = false, nullable = false)
+    private String reasonCode;
+
+    @Column(name = "LIMITID", length = 40, updatable = false)
+    private String limitId;
+
+    @Column(name = "LIMITTYPE", length = 40, updatable = false)
+    private String limitType;
+
+    @Column(name = "LIMITVALUE", precision = 23, scale = 4, updatable = false)
+    private BigDecimal limitValue;
+
+    @Column(name = "LIMITEFFECTIVEFROM", updatable = false)
+    private Instant limitEffectiveFrom;
+
+    @Column(name = "SUBMITTEDBY", length = 50, updatable = false)
+    private String submittedBy;
+
+    @Column(name = "DECISIONTIMESTAMP", updatable = false, nullable = false)
+    private Instant decisionTimestamp;
+
+    protected OrderDecisionAudit() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public Integer getAccountId() {
+        return accountId;
+    }
+
+    public String getSecurity() {
+        return security;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getPriceSource() {
+        return priceSource;
+    }
+
+    public BigDecimal getNotional() {
+        return notional;
+    }
+
+    public DecisionOutcome getDecision() {
+        return decision;
+    }
+
+    public String getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getLimitId() {
+        return limitId;
+    }
+
+    public String getLimitType() {
+        return limitType;
+    }
+
+    public BigDecimal getLimitValue() {
+        return limitValue;
+    }
+
+    public Instant getLimitEffectiveFrom() {
+        return limitEffectiveFrom;
+    }
+
+    public String getSubmittedBy() {
+        return submittedBy;
+    }
+
+    public Instant getDecisionTimestamp() {
+        return decisionTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderDecisionAudit[id=%s, correlationId=%s, decision=%s, reason=%s, account=%s, security=%s]"
+                .formatted(id, correlationId, decision, reasonCode, accountId, security);
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/model/audit/OrderDecisionView.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/model/audit/OrderDecisionView.java
@@ -1,0 +1,54 @@
+package finos.traderx.positionservice.model.audit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Wire representation of a single retained decision.
+ *
+ * The entity is not serialised directly: the JSON shape is what compliance and any downstream
+ * export read, and it should not change silently because a column was renamed. The limit that
+ * was in force is carried by value, exactly as it was captured at decision time.
+ */
+public record OrderDecisionView(
+        String id,
+        String correlationId,
+        String orderId,
+        Integer accountId,
+        String security,
+        String side,
+        Integer quantity,
+        BigDecimal price,
+        String priceSource,
+        BigDecimal notional,
+        DecisionOutcome decision,
+        String reasonCode,
+        String limitId,
+        String limitType,
+        BigDecimal limitValue,
+        Instant limitEffectiveFrom,
+        String submittedBy,
+        Instant decisionTimestamp) {
+
+    public static OrderDecisionView of(OrderDecisionAudit record) {
+        return new OrderDecisionView(
+                record.getId(),
+                record.getCorrelationId(),
+                record.getOrderId(),
+                record.getAccountId(),
+                record.getSecurity(),
+                record.getSide(),
+                record.getQuantity(),
+                record.getPrice(),
+                record.getPriceSource(),
+                record.getNotional(),
+                record.getDecision(),
+                record.getReasonCode(),
+                record.getLimitId(),
+                record.getLimitType(),
+                record.getLimitValue(),
+                record.getLimitEffectiveFrom(),
+                record.getSubmittedBy(),
+                record.getDecisionTimestamp());
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
@@ -24,13 +24,19 @@ import finos.traderx.positionservice.model.audit.OrderDecisionAudit;
  * The ordering is {@code decisionTimestamp desc, id desc} rather than timestamp alone: two
  * decisions can land inside the same millisecond, and a page boundary that falls between them
  * must not be able to drop or duplicate a record.
+ *
+ * The security filter is compared case-insensitively. A reviewer who types a ticker in the wrong
+ * case must not be told there are no decisions for it, and an empty page is indistinguishable
+ * from a genuine absence. The caller is expected to upper-case the parameter; the {@code upper()}
+ * on the column costs {@code IDX_OrderDecisionAudit_Security_Time} on that predicate, which is
+ * the right trade for a filter whose wrong answer is silent.
  */
 public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
 
     String FILTER = """
             from OrderDecisionAudit a
             where (:accountId is null or a.accountId = :accountId)
-              and (:security is null or a.security = :security)
+              and (:security is null or upper(a.security) = :security)
               and (:decision is null or a.decision = :decision)
               and (:from is null or a.decisionTimestamp >= :from)
               and (:to is null or a.decisionTimestamp < :to)

--- a/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
@@ -30,6 +30,10 @@ import finos.traderx.positionservice.model.audit.OrderDecisionAudit;
  * from a genuine absence. The caller is expected to upper-case the parameter; the {@code upper()}
  * on the column costs {@code IDX_OrderDecisionAudit_Security_Time} on that predicate, which is
  * the right trade for a filter whose wrong answer is silent.
+ *
+ * The range parameters are named {@code fromTs}/{@code toTs} rather than {@code from}/{@code to},
+ * which are HQL keywords: Hibernate 6 accepts them in the identifier position, but the spelling
+ * has broken across parser versions before. The HTTP parameter names are unchanged.
  */
 public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
 
@@ -38,8 +42,8 @@ public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAu
             where (:accountId is null or a.accountId = :accountId)
               and (:security is null or upper(a.security) = :security)
               and (:decision is null or a.decision = :decision)
-              and (:from is null or a.decisionTimestamp >= :from)
-              and (:to is null or a.decisionTimestamp < :to)
+              and (:fromTs is null or a.decisionTimestamp >= :fromTs)
+              and (:toTs is null or a.decisionTimestamp < :toTs)
             """;
 
     @Query(value = "select a " + FILTER + " order by a.decisionTimestamp desc, a.id desc",
@@ -47,7 +51,7 @@ public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAu
     Page<OrderDecisionAudit> search(@Param("accountId") Integer accountId,
             @Param("security") String security,
             @Param("decision") DecisionOutcome decision,
-            @Param("from") Instant from,
-            @Param("to") Instant to,
+            @Param("fromTs") Instant from,
+            @Param("toTs") Instant to,
             Pageable pageable);
 }

--- a/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/repository/OrderDecisionAuditRepository.java
@@ -1,0 +1,47 @@
+package finos.traderx.positionservice.repository;
+
+import java.time.Instant;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import finos.traderx.positionservice.model.audit.DecisionOutcome;
+import finos.traderx.positionservice.model.audit.OrderDecisionAudit;
+
+/**
+ * Read-only access to the best-execution audit trail.
+ *
+ * Extends the bare {@link Repository} marker rather than {@code JpaRepository} on purpose, as
+ * TRX-104's writer-side repository does: inheriting {@code CrudRepository} would hand every
+ * caller {@code delete}, {@code deleteAll} and {@code save}, and this service has no business
+ * writing to the record at all. {@code JpaSpecificationExecutor} is avoided for the same reason
+ * - it carries {@code delete(Specification)} - so the filters are expressed as one JPQL query
+ * with optional parameters instead.
+ *
+ * The ordering is {@code decisionTimestamp desc, id desc} rather than timestamp alone: two
+ * decisions can land inside the same millisecond, and a page boundary that falls between them
+ * must not be able to drop or duplicate a record.
+ */
+public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
+
+    String FILTER = """
+            from OrderDecisionAudit a
+            where (:accountId is null or a.accountId = :accountId)
+              and (:security is null or a.security = :security)
+              and (:decision is null or a.decision = :decision)
+              and (:from is null or a.decisionTimestamp >= :from)
+              and (:to is null or a.decisionTimestamp < :to)
+            """;
+
+    @Query(value = "select a " + FILTER + " order by a.decisionTimestamp desc, a.id desc",
+            countQuery = "select count(a) " + FILTER)
+    Page<OrderDecisionAudit> search(@Param("accountId") Integer accountId,
+            @Param("security") String security,
+            @Param("decision") DecisionOutcome decision,
+            @Param("from") Instant from,
+            @Param("to") Instant to,
+            Pageable pageable);
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
@@ -42,7 +42,7 @@ public class AuditQueryService {
     public AuditPage search(Integer accountId, String security, DecisionOutcome decision, Instant from, Instant to,
             Integer page, Integer size) {
         if (from != null && to != null && to.isBefore(from)) {
-            throw new IllegalArgumentException("'to' must not be before 'from'");
+            throw new InvalidAuditQueryException("'to' must not be before 'from'");
         }
         Pageable pageable = pageRequest(page, size);
         Page<OrderDecisionAudit> results = auditRepository.search(accountId, normaliseSecurity(security), decision, from,
@@ -57,11 +57,11 @@ public class AuditQueryService {
     private Pageable pageRequest(Integer page, Integer size) {
         int requestedPage = page == null ? 0 : page;
         if (requestedPage < 0) {
-            throw new IllegalArgumentException("'page' must not be negative");
+            throw new InvalidAuditQueryException("'page' must not be negative");
         }
         int requestedSize = size == null ? properties.getDefaultPageSize() : size;
         if (requestedSize < 1) {
-            throw new IllegalArgumentException("'size' must be at least 1");
+            throw new InvalidAuditQueryException("'size' must be at least 1");
         }
         return PageRequest.of(requestedPage, Math.min(requestedSize, properties.getMaxPageSize()));
     }

--- a/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
@@ -1,0 +1,71 @@
+package finos.traderx.positionservice.service;
+
+import java.time.Instant;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import finos.traderx.positionservice.audit.AuditQueryProperties;
+import finos.traderx.positionservice.model.audit.AuditPage;
+import finos.traderx.positionservice.model.audit.DecisionOutcome;
+import finos.traderx.positionservice.model.audit.OrderDecisionAudit;
+import finos.traderx.positionservice.repository.OrderDecisionAuditRepository;
+
+/**
+ * Query side of the best-execution audit trail. Read-only by construction: it holds a
+ * repository that declares no mutating method.
+ */
+@Service
+public class AuditQueryService {
+
+    private final OrderDecisionAuditRepository auditRepository;
+
+    private final AuditQueryProperties properties;
+
+    public AuditQueryService(OrderDecisionAuditRepository auditRepository, AuditQueryProperties properties) {
+        this.auditRepository = auditRepository;
+        this.properties = properties;
+    }
+
+    public boolean isEnabled() {
+        return properties.isEnabled();
+    }
+
+    /**
+     * @param from inclusive lower bound, @param to exclusive upper bound. Half open so that
+     *             adjacent windows requested by a reviewer neither overlap nor drop a decision
+     *             that landed exactly on the boundary.
+     */
+    public AuditPage search(Integer accountId, String security, DecisionOutcome decision, Instant from, Instant to,
+            Integer page, Integer size) {
+        if (from != null && to != null && to.isBefore(from)) {
+            throw new IllegalArgumentException("'to' must not be before 'from'");
+        }
+        Pageable pageable = pageRequest(page, size);
+        Page<OrderDecisionAudit> results = auditRepository.search(accountId, blankToNull(security), decision, from, to,
+                pageable);
+        return AuditPage.of(results);
+    }
+
+    /**
+     * Unsorted on purpose: the ordering lives in the query so it is applied identically to the
+     * page and to the keys the indexes are built on.
+     */
+    private Pageable pageRequest(Integer page, Integer size) {
+        int requestedPage = page == null ? 0 : page;
+        if (requestedPage < 0) {
+            throw new IllegalArgumentException("'page' must not be negative");
+        }
+        int requestedSize = size == null ? properties.getDefaultPageSize() : size;
+        if (requestedSize < 1) {
+            throw new IllegalArgumentException("'size' must be at least 1");
+        }
+        return PageRequest.of(requestedPage, Math.min(requestedSize, properties.getMaxPageSize()));
+    }
+
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/service/AuditQueryService.java
@@ -1,6 +1,7 @@
 package finos.traderx.positionservice.service;
 
 import java.time.Instant;
+import java.util.Locale;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -44,8 +45,8 @@ public class AuditQueryService {
             throw new IllegalArgumentException("'to' must not be before 'from'");
         }
         Pageable pageable = pageRequest(page, size);
-        Page<OrderDecisionAudit> results = auditRepository.search(accountId, blankToNull(security), decision, from, to,
-                pageable);
+        Page<OrderDecisionAudit> results = auditRepository.search(accountId, normaliseSecurity(security), decision, from,
+                to, pageable);
         return AuditPage.of(results);
     }
 
@@ -65,7 +66,11 @@ public class AuditQueryService {
         return PageRequest.of(requestedPage, Math.min(requestedSize, properties.getMaxPageSize()));
     }
 
-    private String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
+    /**
+     * Trimmed and upper-cased to match the case-insensitive comparison in the query. A ticker
+     * typed in the wrong case must not come back as "no decisions recorded".
+     */
+    private String normaliseSecurity(String value) {
+        return value == null || value.isBlank() ? null : value.trim().toUpperCase(Locale.ROOT);
     }
 }

--- a/position-service/src/main/java/finos/traderx/positionservice/service/InvalidAuditQueryException.java
+++ b/position-service/src/main/java/finos/traderx/positionservice/service/InvalidAuditQueryException.java
@@ -1,0 +1,15 @@
+package finos.traderx.positionservice.service;
+
+/**
+ * A query the caller got wrong, carrying a message written for the caller.
+ *
+ * Distinct from {@link IllegalArgumentException} so that the controller can answer with the message
+ * verbatim: anything thrown below this service, by the persistence provider or elsewhere, carries
+ * query and mapping detail that this endpoint must not hand back.
+ */
+public class InvalidAuditQueryException extends RuntimeException {
+
+    public InvalidAuditQueryException(String message) {
+        super(message);
+    }
+}

--- a/position-service/src/main/resources/application.properties
+++ b/position-service/src/main/resources/application.properties
@@ -9,5 +9,12 @@ spring.data.jpa.show-sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.threads.virtual.enabled=true
 
+# MiFID II RTS 27/28 best-execution audit trail, query side (TRX-105). The table itself is
+# owned and written by trade-service (TRX-104); this service only reads it.
+# Single kill switch for the compliance API and the blotter tab it feeds, on in dev.
+audit.query.enabled=${AUDIT_QUERY_ENABLED:true}
+audit.query.default-page-size=${AUDIT_QUERY_DEFAULT_PAGE_SIZE:50}
+audit.query.max-page-size=${AUDIT_QUERY_MAX_PAGE_SIZE:500}
+
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
@@ -101,6 +101,22 @@ class AuditControllerTest {
                 .andExpect(jsonPath("$.message").value(not(containsString("java."))));
     }
 
+
+    @Test
+    void acceptsAnInstantWithAnyOffsetAndRejectsOneWithout() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+        when(auditQueryService.search(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new AuditPage(List.of(), 0, 50, 0L, 0));
+
+        mockMvc.perform(get("/audit/decisions").param("from", "2026-01-01T01:00:00+01:00"))
+                .andExpect(status().isOk());
+        verify(auditQueryService).search(isNull(), isNull(), isNull(), eq(Instant.parse("2026-01-01T00:00:00Z")),
+                isNull(), isNull(), isNull());
+
+        mockMvc.perform(get("/audit/decisions").param("from", "2026-01-01T00:00:00"))
+                .andExpect(status().isBadRequest());
+    }
+
     @Test
     void keepsAFailureFromBelowTheServiceOutOfTheResponse() throws Exception {
         when(auditQueryService.isEnabled()).thenReturn(true);

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
@@ -83,6 +83,14 @@ class AuditControllerTest {
     }
 
     @Test
+    void reportsAnUnparseableFilterAsABadRequestRatherThanAnOutage() throws Exception {
+        mockMvc.perform(get("/audit/decisions").param("from", "last Tuesday")).andExpect(status().isBadRequest());
+        mockMvc.perform(get("/audit/decisions").param("accountId", "all")).andExpect(status().isBadRequest());
+
+        verify(auditQueryService, never()).search(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
     void returnsServiceUnavailableAndQueriesNothingWhenTheFeatureIsOff() throws Exception {
         when(auditQueryService.isEnabled()).thenReturn(false);
 

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
@@ -102,6 +102,17 @@ class AuditControllerTest {
     }
 
     @Test
+    void keepsAFailureFromBelowTheServiceOutOfTheResponse() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+        when(auditQueryService.search(any(), any(), any(), any(), any(), any(), any()))
+                .thenThrow(new IllegalArgumentException("Parameter value [x] did not match expected type in ORDERDECISIONAUDIT"));
+
+        mockMvc.perform(get("/audit/decisions"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("Could not query the audit trail."));
+    }
+
+    @Test
     void reportsAnUnparseableFilterAsABadRequestRatherThanAnOutage() throws Exception {
         mockMvc.perform(get("/audit/decisions").param("from", "last Tuesday")).andExpect(status().isBadRequest());
         mockMvc.perform(get("/audit/decisions").param("accountId", "all")).andExpect(status().isBadRequest());

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
@@ -1,0 +1,93 @@
+package finos.traderx.positionservice.audit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import finos.traderx.positionservice.controller.AuditController;
+import finos.traderx.positionservice.model.audit.AuditPage;
+import finos.traderx.positionservice.model.audit.DecisionOutcome;
+import finos.traderx.positionservice.service.AuditQueryService;
+
+@ExtendWith(MockitoExtension.class)
+class AuditControllerTest {
+
+    @Mock
+    private AuditQueryService auditQueryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new AuditController(auditQueryService)).build();
+    }
+
+    @Test
+    void passesFiltersThroughAndReturnsAPagedEnvelope() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+        when(auditQueryService.search(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new AuditPage(List.of(), 2, 25, 120L, 5));
+
+        mockMvc.perform(get("/audit/decisions")
+                .param("accountId", "11413")
+                .param("security", "AAPL")
+                .param("decision", "rejected")
+                .param("from", "2026-01-01T00:00:00Z")
+                .param("to", "2026-02-01T00:00:00Z")
+                .param("page", "2")
+                .param("size", "25"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(120))
+                .andExpect(jsonPath("$.totalPages").value(5))
+                .andExpect(jsonPath("$.page").value(2));
+
+        verify(auditQueryService).search(eq(11413), eq("AAPL"), eq(DecisionOutcome.REJECTED),
+                eq(Instant.parse("2026-01-01T00:00:00Z")), eq(Instant.parse("2026-02-01T00:00:00Z")), eq(2), eq(25));
+    }
+
+    @Test
+    void unfilteredQueryReachesTheServiceWithNoBounds() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+        when(auditQueryService.search(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new AuditPage(List.of(), 0, 50, 0L, 0));
+
+        mockMvc.perform(get("/audit/decisions")).andExpect(status().isOk());
+
+        verify(auditQueryService).search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void rejectsAnUnknownDecisionRatherThanWideningTheQuery() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+
+        mockMvc.perform(get("/audit/decisions").param("decision", "MAYBE")).andExpect(status().isBadRequest());
+
+        verify(auditQueryService, never()).search(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void returnsServiceUnavailableAndQueriesNothingWhenTheFeatureIsOff() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(false);
+
+        mockMvc.perform(get("/audit/decisions")).andExpect(status().isServiceUnavailable());
+
+        verify(auditQueryService, never()).search(any(), any(), any(), any(), any(), any(), any());
+    }
+}

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditControllerTest.java
@@ -1,5 +1,7 @@
 package finos.traderx.positionservice.audit;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -7,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -18,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -80,6 +84,21 @@ class AuditControllerTest {
         mockMvc.perform(get("/audit/decisions").param("decision", "MAYBE")).andExpect(status().isBadRequest());
 
         verify(auditQueryService, never()).search(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void answersErrorsWithJsonThatDoesNotEchoWhatTheCallerSent() throws Exception {
+        when(auditQueryService.isEnabled()).thenReturn(true);
+
+        mockMvc.perform(get("/audit/decisions").param("decision", "<script>alert(1)</script>"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("Expected one of")))
+                .andExpect(jsonPath("$.message").value(not(containsString("script"))));
+
+        mockMvc.perform(get("/audit/decisions").param("accountId", "all"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(not(containsString("java."))));
     }
 
     @Test

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
@@ -22,6 +22,7 @@ import finos.traderx.positionservice.model.audit.DecisionOutcome;
 import finos.traderx.positionservice.model.audit.OrderDecisionView;
 import finos.traderx.positionservice.repository.OrderDecisionAuditRepository;
 import finos.traderx.positionservice.service.AuditQueryService;
+import finos.traderx.positionservice.service.InvalidAuditQueryException;
 
 @DataJpaTest
 @TestPropertySource(properties = { "spring.jpa.hibernate.ddl-auto=create-drop" })
@@ -101,10 +102,10 @@ class AuditQueryServiceTest {
 
     @Test
     void rejectsNonsensicalPagingAndRanges() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidAuditQueryException.class,
                 () -> service.search(null, null, null, T0.plusSeconds(180), T0, null, null));
-        assertThrows(IllegalArgumentException.class, () -> service.search(null, null, null, null, null, -1, null));
-        assertThrows(IllegalArgumentException.class, () -> service.search(null, null, null, null, null, 0, 0));
+        assertThrows(InvalidAuditQueryException.class, () -> service.search(null, null, null, null, null, -1, null));
+        assertThrows(InvalidAuditQueryException.class, () -> service.search(null, null, null, null, null, 0, 0));
     }
 
     @Test

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
@@ -67,6 +67,12 @@ class AuditQueryServiceTest {
     }
 
     @Test
+    void findsATickerRegardlessOfTheCaseOrSpacingItWasTypedIn() {
+        assertEquals(List.of("a4", "a3", "a1"), ids(service.search(null, "aapl", null, null, null, null, null)));
+        assertEquals(List.of("a4", "a3", "a1"), ids(service.search(null, " AaPl ", null, null, null, null, null)));
+    }
+
+    @Test
     void timeRangeIsInclusiveOfFromAndExclusiveOfTo() {
         AuditPage page = service.search(null, null, null, T0.plusSeconds(60), T0.plusSeconds(180), null, null);
         assertEquals(List.of("a3", "a2"), ids(page));

--- a/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
+++ b/position-service/src/test/java/finos/traderx/positionservice/audit/AuditQueryServiceTest.java
@@ -1,0 +1,139 @@
+package finos.traderx.positionservice.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import finos.traderx.positionservice.model.audit.AuditPage;
+import finos.traderx.positionservice.model.audit.DecisionOutcome;
+import finos.traderx.positionservice.model.audit.OrderDecisionView;
+import finos.traderx.positionservice.repository.OrderDecisionAuditRepository;
+import finos.traderx.positionservice.service.AuditQueryService;
+
+@DataJpaTest
+@TestPropertySource(properties = { "spring.jpa.hibernate.ddl-auto=create-drop" })
+class AuditQueryServiceTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T10:00:00Z");
+
+    @Autowired
+    private OrderDecisionAuditRepository repository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private AuditQueryService service;
+
+    private AuditQueryProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AuditQueryProperties();
+        service = new AuditQueryService(repository, properties);
+        jdbcTemplate.update("DELETE FROM ORDERDECISIONAUDIT");
+
+        insert("a1", 11413, "AAPL", DecisionOutcome.ACCEPTED, "VALIDATED", T0);
+        insert("a2", 11413, "MSFT", DecisionOutcome.REJECTED, "ACCOUNT_LIMIT_BREACHED", T0.plusSeconds(60));
+        insert("a3", 42422, "AAPL", DecisionOutcome.REJECTED, "SECURITY_NOT_FOUND", T0.plusSeconds(120));
+        insert("a4", 42422, "AAPL", DecisionOutcome.ACCEPTED, "VALIDATED", T0.plusSeconds(180));
+    }
+
+    @Test
+    void returnsEverythingNewestFirstWhenNoFilterIsGiven() {
+        assertEquals(List.of("a4", "a3", "a2", "a1"), ids(service.search(null, null, null, null, null, null, null)));
+    }
+
+    @Test
+    void filtersByAccountSecurityAndDecision() {
+        assertEquals(List.of("a2", "a1"), ids(service.search(11413, null, null, null, null, null, null)));
+        assertEquals(List.of("a4", "a3", "a1"), ids(service.search(null, "AAPL", null, null, null, null, null)));
+        assertEquals(List.of("a3", "a2"),
+                ids(service.search(null, null, DecisionOutcome.REJECTED, null, null, null, null)));
+        assertEquals(List.of("a3"),
+                ids(service.search(42422, "AAPL", DecisionOutcome.REJECTED, null, null, null, null)));
+    }
+
+    @Test
+    void timeRangeIsInclusiveOfFromAndExclusiveOfTo() {
+        AuditPage page = service.search(null, null, null, T0.plusSeconds(60), T0.plusSeconds(180), null, null);
+        assertEquals(List.of("a3", "a2"), ids(page));
+    }
+
+    @Test
+    void pagesWithoutLosingOrDuplicatingRecords() {
+        AuditPage first = service.search(null, null, null, null, null, 0, 3);
+        AuditPage second = service.search(null, null, null, null, null, 1, 3);
+
+        assertEquals(List.of("a4", "a3", "a2"), ids(first));
+        assertEquals(List.of("a1"), ids(second));
+        assertEquals(4, first.totalElements());
+        assertEquals(2, first.totalPages());
+    }
+
+    @Test
+    void clampsRequestedPageSizeToTheConfiguredCeiling() {
+        properties.setMaxPageSize(2);
+
+        AuditPage page = service.search(null, null, null, null, null, 0, 1000);
+
+        assertEquals(2, page.size());
+        assertEquals(List.of("a4", "a3"), ids(page));
+    }
+
+    @Test
+    void rejectsNonsensicalPagingAndRanges() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.search(null, null, null, T0.plusSeconds(180), T0, null, null));
+        assertThrows(IllegalArgumentException.class, () -> service.search(null, null, null, null, null, -1, null));
+        assertThrows(IllegalArgumentException.class, () -> service.search(null, null, null, null, null, 0, 0));
+    }
+
+    @Test
+    void emptyResultIsAnEmptyPageRatherThanAnError() {
+        AuditPage page = service.search(99999, null, null, null, null, null, null);
+
+        assertTrue(page.content().isEmpty());
+        assertEquals(0, page.totalElements());
+    }
+
+    @Test
+    void carriesTheLimitSnapshotThatWasInForceAtDecisionTime() {
+        OrderDecisionView view = service.search(null, null, DecisionOutcome.REJECTED, null, null, null, null).content()
+                .get(0);
+
+        assertEquals("DEFAULT-ACCOUNT-NOTIONAL", view.limitId());
+        assertEquals(new BigDecimal("5000000.0000"), view.limitValue());
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), view.limitEffectiveFrom());
+    }
+
+    private List<String> ids(AuditPage page) {
+        return page.content().stream().map(OrderDecisionView::id).toList();
+    }
+
+    private void insert(String id, Integer accountId, String security, DecisionOutcome decision, String reasonCode,
+            Instant at) {
+        jdbcTemplate.update("""
+                INSERT INTO ORDERDECISIONAUDIT (ID, CORRELATIONID, ORDERID, ACCOUNTID, SECURITY, SIDE, QUANTITY,
+                    PRICE, PRICESOURCE, NOTIONAL, DECISION, REASONCODE, LIMITID, LIMITTYPE, LIMITVALUE,
+                    LIMITEFFECTIVEFROM, SUBMITTEDBY, DECISIONTIMESTAMP)
+                VALUES (?, ?, ?, ?, ?, 'Buy', 100, 100.0000, 'CONFIGURED_STATIC_REFERENCE_PRICE', 10000.0000,
+                    ?, ?, 'DEFAULT-ACCOUNT-NOTIONAL', 'ACCOUNT_NOTIONAL', 5000000.0000, ?, 'trader1', ?)
+                """,
+                id, "corr-" + id, "order-" + id, accountId, security, decision.name(), reasonCode,
+                OffsetDateTime.ofInstant(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC),
+                OffsetDateTime.ofInstant(at, ZoneOffset.UTC));
+    }
+}

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/Trade.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/Trade.java
@@ -101,6 +101,18 @@ public class Trade implements Serializable {
 	}
 
 
+	/** Ties the booked trade back to its OrderDecisionAudit record written by trade-service. */
+	@Column(length = 50, name = "CORRELATIONID")
+	private String correlationId;
+
+	public String getCorrelationId() {
+		return this.correlationId;
+	}
+
+	public void setCorrelationId(String correlationId) {
+		this.correlationId = correlationId;
+	}
+
 	@Column(name = "CREATED")
 	private Date created;
 

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
@@ -8,6 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    private String correlationId;
 
     public TradeOrder(){}
     
@@ -41,5 +42,13 @@ public class TradeOrder {
 
     public TradeSide getSide() {
         return side;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 }

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
@@ -41,6 +41,7 @@ public class TradeService {
 		t.setId(UUID.randomUUID().toString());
 
 
+        t.setCorrelationId(order.getCorrelationId());
         t.setCreated(new Date());
         t.setUpdated(new Date());
         t.setSecurity(order.getSecurity());

--- a/trade-processor/src/test/java/finos/traderx/tradeprocessor/service/TradeServiceCorrelationTest.java
+++ b/trade-processor/src/test/java/finos/traderx/tradeprocessor/service/TradeServiceCorrelationTest.java
@@ -1,0 +1,72 @@
+package finos.traderx.tradeprocessor.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeprocessor.model.Position;
+import finos.traderx.tradeprocessor.model.Trade;
+import finos.traderx.tradeprocessor.model.TradeOrder;
+import finos.traderx.tradeprocessor.model.TradeSide;
+import finos.traderx.tradeprocessor.repository.PositionRepository;
+import finos.traderx.tradeprocessor.repository.TradeRepository;
+
+/**
+ * The audit record written at decision time is only useful if it can be tied to what was
+ * actually booked, so the correlation id has to survive the trip over the trade feed.
+ */
+class TradeServiceCorrelationTest {
+
+    private TradeRepository tradeRepository;
+    private PositionRepository positionRepository;
+    private TradeService tradeService;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        tradeRepository = mock(TradeRepository.class);
+        positionRepository = mock(PositionRepository.class);
+        when(tradeRepository.save(any(Trade.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(positionRepository.save(any(Position.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(positionRepository.findByAccountIdAndSecurity(anyInt(), anyString())).thenReturn(null);
+
+        tradeService = new TradeService();
+        ReflectionTestUtils.setField(tradeService, "tradeRepository", tradeRepository);
+        ReflectionTestUtils.setField(tradeService, "positionRepository", positionRepository);
+        ReflectionTestUtils.setField(tradeService, "tradePublisher", mock(Publisher.class));
+        ReflectionTestUtils.setField(tradeService, "positionPublisher", mock(Publisher.class));
+    }
+
+    @Test
+    void carriesTheDecisionCorrelationIdOntoTheBookedTrade() {
+        TradeOrder order = new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 100);
+        order.setCorrelationId("CORR-1");
+
+        Trade booked = tradeService.processTrade(order).getTrade();
+
+        assertEquals("CORR-1", booked.getCorrelationId());
+        ArgumentCaptor<Trade> captor = ArgumentCaptor.forClass(Trade.class);
+        verify(tradeRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
+        assertEquals("CORR-1", captor.getValue().getCorrelationId());
+    }
+
+    @Test
+    void leavesTheCorrelationIdUnsetForLegacyOrdersWithoutOne() {
+        TradeOrder order = new TradeOrder("ORDER-2", 22214, "MS", TradeSide.Sell, 50);
+
+        var result = tradeService.processTrade(order);
+
+        assertEquals(null, result.getTrade().getCorrelationId());
+        assertEquals(-50, result.getPosition().getQuantity());
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/HttpClientConfig.java
@@ -1,0 +1,14 @@
+package finos.traderx.tradeservice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/AuditConfig.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/AuditConfig.java
@@ -1,0 +1,18 @@
+package finos.traderx.tradeservice.audit;
+
+import java.time.Clock;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(BestExecutionAuditProperties.class)
+public class AuditConfig {
+
+    /** UTC, because the retained record has to be in UTC regardless of where the JVM runs. */
+    @Bean
+    public Clock auditClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/BestExecutionAuditProperties.java
@@ -1,0 +1,105 @@
+package finos.traderx.tradeservice.audit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Externalised configuration for the best-execution audit trail. Nothing here is hard-coded
+ * in the decision path; see application.properties for the dev defaults.
+ */
+@ConfigurationProperties(prefix = "audit.best-execution")
+public class BestExecutionAuditProperties {
+
+    /** Kill switch for the whole feature. Defaults to on in dev. */
+    private boolean enabled = true;
+
+    private final Limit limit = new Limit();
+
+    private final Pricing pricing = new Pricing();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Limit getLimit() {
+        return limit;
+    }
+
+    public Pricing getPricing() {
+        return pricing;
+    }
+
+    /**
+     * The limit snapshot recorded against each decision until TRX-102 provides a real
+     * limits store to read from.
+     */
+    public static class Limit {
+        private String id = "DEFAULT-ACCOUNT-NOTIONAL";
+        private String type = "ACCOUNT_NOTIONAL";
+        private BigDecimal value = new BigDecimal("5000000.0000");
+        private Instant effectiveFrom = Instant.parse("2024-01-01T00:00:00Z");
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public BigDecimal getValue() {
+            return value;
+        }
+
+        public void setValue(BigDecimal value) {
+            this.value = value;
+        }
+
+        public Instant getEffectiveFrom() {
+            return effectiveFrom;
+        }
+
+        public void setEffectiveFrom(Instant effectiveFrom) {
+            this.effectiveFrom = effectiveFrom;
+        }
+    }
+
+    /**
+     * TraderX has no market data service, so the price used to compute notional comes from
+     * configuration and is labelled as such in every record.
+     */
+    public static class Pricing {
+        private BigDecimal referencePrice = new BigDecimal("100.0000");
+        private String source = "CONFIGURED_STATIC_REFERENCE_PRICE";
+
+        public BigDecimal getReferencePrice() {
+            return referencePrice;
+        }
+
+        public void setReferencePrice(BigDecimal referencePrice) {
+            this.referencePrice = referencePrice;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -1,0 +1,85 @@
+package finos.traderx.tradeservice.audit;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.EvaluatedLimit;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+import finos.traderx.tradeservice.repository.OrderDecisionAuditRepository;
+
+/**
+ * Writes the append-only best-execution record for every order submission.
+ *
+ * The write is synchronous with the decision and commits in its own transaction, so the
+ * record survives a later failure in the same request (a publish error, for instance).
+ */
+@Service
+public class OrderDecisionAuditService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderDecisionAuditService.class);
+
+    private final OrderDecisionAuditRepository repository;
+    private final BestExecutionAuditProperties properties;
+    private final Clock clock;
+
+    public OrderDecisionAuditService(OrderDecisionAuditRepository repository,
+            BestExecutionAuditProperties properties, Clock clock) {
+        this.repository = repository;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public OrderDecisionAudit recordDecision(TradeOrder order, String correlationId, DecisionOutcome decision,
+            DecisionReason reason, String submittedBy) {
+        if (!properties.isEnabled()) {
+            log.warn("Best-execution audit disabled; no record written for correlation id {}", correlationId);
+            return null;
+        }
+
+        BigDecimal price = properties.getPricing().getReferencePrice();
+        BigDecimal notional = notionalOf(order, price);
+        EvaluatedLimit limit = new EvaluatedLimit(properties.getLimit().getId(), properties.getLimit().getType(),
+                properties.getLimit().getValue(), properties.getLimit().getEffectiveFrom());
+
+        OrderDecisionAudit auditRecord = new OrderDecisionAudit(
+                UUID.randomUUID().toString(),
+                correlationId,
+                order.getId(),
+                order.getAccountId(),
+                order.getSecurity(),
+                order.getSide() == null ? null : order.getSide().toString(),
+                order.getQuantity(),
+                price,
+                properties.getPricing().getSource(),
+                notional,
+                decision,
+                reason,
+                limit,
+                submittedBy,
+                Instant.now(clock).truncatedTo(ChronoUnit.MILLIS));
+
+        OrderDecisionAudit saved = repository.save(auditRecord);
+        log.info("Best-execution audit record written: {}", saved);
+        return saved;
+    }
+
+    private BigDecimal notionalOf(TradeOrder order, BigDecimal price) {
+        if (order.getQuantity() == null || price == null) {
+            return null;
+        }
+        return price.multiply(BigDecimal.valueOf(order.getQuantity()));
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/audit/OrderDecisionAuditService.java
@@ -45,7 +45,7 @@ public class OrderDecisionAuditService {
     public OrderDecisionAudit recordDecision(TradeOrder order, String correlationId, DecisionOutcome decision,
             DecisionReason reason, String submittedBy) {
         if (!properties.isEnabled()) {
-            log.warn("Best-execution audit disabled; no record written for correlation id {}", correlationId);
+            log.debug("Best-execution audit disabled; no record written for correlation id {}", correlationId);
             return null;
         }
 

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import finos.traderx.messaging.PubSubException;
@@ -38,13 +39,29 @@ public class TradeOrderController {
 	private static final String SUBMITTING_USER_HEADER = "X-TraderX-User";
 	private static final String UNKNOWN_USER = "UNKNOWN";
 
-	@Autowired
-	private Publisher<TradeOrder> tradePublisher;
+	/** Length of the SUBMITTEDBY column; an over-long header must not fail the audit insert. */
+	private static final int SUBMITTED_BY_MAX_LENGTH = 50;
+
+	private final Publisher<TradeOrder> tradePublisher;
+
+	private final OrderDecisionAuditService orderDecisionAuditService;
+
+	private final RestTemplate restTemplate;
 
 	@Autowired
-	private OrderDecisionAuditService orderDecisionAuditService;
-	
-	private RestTemplate restTemplate = new RestTemplate();
+	public TradeOrderController(Publisher<TradeOrder> tradePublisher,
+			OrderDecisionAuditService orderDecisionAuditService, RestTemplate restTemplate) {
+		this.tradePublisher = tradePublisher;
+		this.orderDecisionAuditService = orderDecisionAuditService;
+		this.restTemplate = restTemplate;
+	}
+
+	/** Outcome of a downstream existence check. "Not found" and "could not ask" are different facts. */
+	enum LookupResult {
+		FOUND,
+		NOT_FOUND,
+		UNAVAILABLE
+	}
 
 	@Value("${reference.data.service.url}")
 	private String referenceDataServiceAddress;
@@ -60,15 +77,30 @@ public class TradeOrderController {
 
 		String correlationId = UUID.randomUUID().toString();
 		tradeOrder.setCorrelationId(correlationId);
-		String submittedBy = (submittingUser == null || submittingUser.isBlank()) ? UNKNOWN_USER : submittingUser;
+		String submittedBy = submittedBy(submittingUser);
 
-		if (!validateTicker(tradeOrder.getSecurity())) 
+		LookupResult tickerLookup = validateTicker(tradeOrder.getSecurity());
+		if (tickerLookup == LookupResult.UNAVAILABLE)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
+			throw new RuntimeException("Could not validate " + tradeOrder.getSecurity() + " against Reference data service.");
+		}
+		else if (tickerLookup == LookupResult.NOT_FOUND) 
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.SECURITY_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");
 		}
-		else if(!validateAccount(tradeOrder.getAccountId()))
+
+		LookupResult accountLookup = validateAccount(tradeOrder.getAccountId());
+		if (accountLookup == LookupResult.UNAVAILABLE)
+		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.VALIDATION_UNAVAILABLE, submittedBy);
+			throw new RuntimeException("Could not validate account " + tradeOrder.getAccountId() + " against Account service.");
+		}
+		else if(accountLookup == LookupResult.NOT_FOUND)
 		{
 			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
 					DecisionReason.ACCOUNT_NOT_FOUND, submittedBy);
@@ -88,7 +120,16 @@ public class TradeOrderController {
 		}
 	}
 
-	private boolean validateTicker(String ticker)
+	private String submittedBy(String submittingUser)
+	{
+		if (submittingUser == null || submittingUser.isBlank()) {
+			return UNKNOWN_USER;
+		}
+		String trimmed = submittingUser.trim();
+		return trimmed.length() > SUBMITTED_BY_MAX_LENGTH ? trimmed.substring(0, SUBMITTED_BY_MAX_LENGTH) : trimmed;
+	}
+
+	private LookupResult validateTicker(String ticker)
 	{
 		// Move whole method to a sperate class that handles all reference data 
 		// so we can mock it and run without this service up.
@@ -98,20 +139,23 @@ public class TradeOrderController {
 		try {
 			response = this.restTemplate.getForEntity(url, Security.class);
 			log.info("Validate ticker " + response.getBody().toString());
-			return true;
+			return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
+			if (ex.getStatusCode().value() == 404) {
 				log.info(ticker + " not found in reference data service.");
+				return LookupResult.NOT_FOUND;
 			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
+			log.error(ex.getMessage());
+			return LookupResult.UNAVAILABLE;
+		}
+		catch (RestClientException ex) {
+			log.error("Reference data service unavailable while validating " + ticker, ex);
+			return LookupResult.UNAVAILABLE;
 		}
 	}		
 	
-	private boolean validateAccount(Integer id)
+	private LookupResult validateAccount(Integer id)
 	{
 		// Move whole method to a sperate class that handles all accounts 
 		// so we can mock it and run without this service up.
@@ -123,16 +167,19 @@ public class TradeOrderController {
 		{
 				response = this.restTemplate.getForEntity(url, Account.class);
 				log.info("Validate account " + response.getBody().toString());
-				return true;
+				return LookupResult.FOUND;
 		}
 		catch (HttpClientErrorException ex) {
-			if (ex.getRawStatusCode() == 404) {
+			if (ex.getStatusCode().value() == 404) {
 				log.info("Account" + id + " not found in account service.");				
+				return LookupResult.NOT_FOUND;
 			}
-			else {
-				log.error(ex.getMessage());
-			}
-			return false;
+			log.error(ex.getMessage());
+			return LookupResult.UNAVAILABLE;
+		}
+		catch (RestClientException ex) {
+			log.error("Account service unavailable while validating account " + id, ex);
+			return LookupResult.UNAVAILABLE;
 		}
 	}
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -1,5 +1,7 @@
 package finos.traderx.tradeservice.controller;
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -18,7 +21,10 @@ import finos.traderx.messaging.Publisher;
 import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
 import finos.traderx.tradeservice.model.Account;
 import finos.traderx.tradeservice.model.Security;
+import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
 import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -29,8 +35,14 @@ public class TradeOrderController {
 
 	private static final Logger log = LoggerFactory.getLogger(TradeOrderController.class);
 
+	private static final String SUBMITTING_USER_HEADER = "X-TraderX-User";
+	private static final String UNKNOWN_USER = "UNKNOWN";
+
 	@Autowired
 	private Publisher<TradeOrder> tradePublisher;
+
+	@Autowired
+	private OrderDecisionAuditService orderDecisionAuditService;
 	
 	private RestTemplate restTemplate = new RestTemplate();
 
@@ -42,19 +54,30 @@ public class TradeOrderController {
 
 	@Operation(description = "Submit a new trade order")
 	@PostMapping("/")
-	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder) {
+	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder,
+			@Parameter(description = "user submitting the order, recorded in the audit trail") @RequestHeader(value = SUBMITTING_USER_HEADER, required = false) String submittingUser) {
 		log.info("Called createTradeOrder");
-		
+
+		String correlationId = UUID.randomUUID().toString();
+		tradeOrder.setCorrelationId(correlationId);
+		String submittedBy = (submittingUser == null || submittingUser.isBlank()) ? UNKNOWN_USER : submittingUser;
+
 		if (!validateTicker(tradeOrder.getSecurity())) 
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.SECURITY_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");
 		}
 		else if(!validateAccount(tradeOrder.getAccountId()))
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.REJECTED,
+					DecisionReason.ACCOUNT_NOT_FOUND, submittedBy);
 			throw new ResourceNotFoundException(tradeOrder.getAccountId() + " not found in Account service.");
 		}
 		else
 		{
+			orderDecisionAuditService.recordDecision(tradeOrder, correlationId, DecisionOutcome.ACCEPTED,
+					DecisionReason.VALIDATED, submittedBy);
 			try{
 				log.info("Trade is valid. Submitting {}", tradeOrder);
 				tradePublisher.publish("/trades",tradeOrder);

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
@@ -8,6 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    private String correlationId;
 
     public TradeOrder(){}
     
@@ -41,5 +42,13 @@ public class TradeOrder {
 
     public TradeSide getSide() {
         return side;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionOutcome.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionOutcome.java
@@ -1,0 +1,6 @@
+package finos.traderx.tradeservice.model.audit;
+
+public enum DecisionOutcome {
+    ACCEPTED,
+    REJECTED
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -1,0 +1,11 @@
+package finos.traderx.tradeservice.model.audit;
+
+/**
+ * Machine readable reason attached to every order decision. Values are part of the
+ * retained regulatory record and must not be renamed once written.
+ */
+public enum DecisionReason {
+    VALIDATED,
+    SECURITY_NOT_FOUND,
+    ACCOUNT_NOT_FOUND
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/DecisionReason.java
@@ -7,5 +7,7 @@ package finos.traderx.tradeservice.model.audit;
 public enum DecisionReason {
     VALIDATED,
     SECURITY_NOT_FOUND,
-    ACCOUNT_NOT_FOUND
+    ACCOUNT_NOT_FOUND,
+    /** A downstream check could not be performed, so the order was refused without being validated. */
+    VALIDATION_UNAVAILABLE
 }

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/EvaluatedLimit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/EvaluatedLimit.java
@@ -1,0 +1,11 @@
+package finos.traderx.tradeservice.model.audit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Snapshot of the limit that was in force when a decision was taken. Copied into the audit
+ * record by value so the decision stays reconstructable after the limit is later amended.
+ */
+public record EvaluatedLimit(String limitId, String limitType, BigDecimal limitValue, Instant effectiveFrom) {
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/audit/OrderDecisionAudit.java
@@ -1,0 +1,204 @@
+package finos.traderx.tradeservice.model.audit;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.hibernate.annotations.Immutable;
+import org.springframework.data.domain.Persistable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Append-only record of a single order decision, retained under MiFID II Art. 16(6).
+ *
+ * Immutability is enforced in three places: Hibernate never issues an UPDATE for an
+ * {@link Immutable} entity, every column is mapped {@code updatable = false}, and the type
+ * exposes no setters. The repository deliberately exposes no delete operation.
+ */
+@Entity
+@Immutable
+@Table(name = "ORDERDECISIONAUDIT")
+public class OrderDecisionAudit implements Persistable<String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", length = 50, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "CORRELATIONID", length = 50, updatable = false, nullable = false)
+    private String correlationId;
+
+    @Column(name = "ORDERID", length = 50, updatable = false)
+    private String orderId;
+
+    @Column(name = "ACCOUNTID", updatable = false)
+    private Integer accountId;
+
+    @Column(name = "SECURITY", length = 50, updatable = false)
+    private String security;
+
+    @Column(name = "SIDE", length = 10, updatable = false)
+    private String side;
+
+    @Column(name = "QUANTITY", updatable = false)
+    private Integer quantity;
+
+    @Column(name = "PRICE", precision = 19, scale = 4, updatable = false)
+    private BigDecimal price;
+
+    @Column(name = "PRICESOURCE", length = 40, updatable = false)
+    private String priceSource;
+
+    @Column(name = "NOTIONAL", precision = 23, scale = 4, updatable = false)
+    private BigDecimal notional;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "DECISION", length = 10, updatable = false, nullable = false)
+    private DecisionOutcome decision;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "REASONCODE", length = 40, updatable = false, nullable = false)
+    private DecisionReason reasonCode;
+
+    @Column(name = "LIMITID", length = 40, updatable = false)
+    private String limitId;
+
+    @Column(name = "LIMITTYPE", length = 40, updatable = false)
+    private String limitType;
+
+    @Column(name = "LIMITVALUE", precision = 23, scale = 4, updatable = false)
+    private BigDecimal limitValue;
+
+    @Column(name = "LIMITEFFECTIVEFROM", updatable = false)
+    private Instant limitEffectiveFrom;
+
+    @Column(name = "SUBMITTEDBY", length = 50, updatable = false)
+    private String submittedBy;
+
+    @Column(name = "DECISIONTIMESTAMP", updatable = false, nullable = false)
+    private Instant decisionTimestamp;
+
+    protected OrderDecisionAudit() {
+    }
+
+    public OrderDecisionAudit(String id, String correlationId, String orderId, Integer accountId, String security,
+            String side, Integer quantity, BigDecimal price, String priceSource, BigDecimal notional,
+            DecisionOutcome decision, DecisionReason reasonCode, EvaluatedLimit limit, String submittedBy,
+            Instant decisionTimestamp) {
+        this.id = id;
+        this.correlationId = correlationId;
+        this.orderId = orderId;
+        this.accountId = accountId;
+        this.security = security;
+        this.side = side;
+        this.quantity = quantity;
+        this.price = price;
+        this.priceSource = priceSource;
+        this.notional = notional;
+        this.decision = decision;
+        this.reasonCode = reasonCode;
+        if (limit != null) {
+            this.limitId = limit.limitId();
+            this.limitType = limit.limitType();
+            this.limitValue = limit.limitValue();
+            this.limitEffectiveFrom = limit.effectiveFrom();
+        }
+        this.submittedBy = submittedBy;
+        this.decisionTimestamp = decisionTimestamp;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Always new. An audit record is inserted once and never merged back, so the persistence
+     * provider must never be given the chance to turn a save into an UPDATE.
+     */
+    @Override
+    public boolean isNew() {
+        return true;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public Integer getAccountId() {
+        return accountId;
+    }
+
+    public String getSecurity() {
+        return security;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getPriceSource() {
+        return priceSource;
+    }
+
+    public BigDecimal getNotional() {
+        return notional;
+    }
+
+    public DecisionOutcome getDecision() {
+        return decision;
+    }
+
+    public DecisionReason getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getLimitId() {
+        return limitId;
+    }
+
+    public String getLimitType() {
+        return limitType;
+    }
+
+    public BigDecimal getLimitValue() {
+        return limitValue;
+    }
+
+    public Instant getLimitEffectiveFrom() {
+        return limitEffectiveFrom;
+    }
+
+    public String getSubmittedBy() {
+        return submittedBy;
+    }
+
+    public Instant getDecisionTimestamp() {
+        return decisionTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderDecisionAudit[id=%s, correlationId=%s, decision=%s, reason=%s, account=%s, security=%s, notional=%s]"
+                .formatted(id, correlationId, decision, reasonCode, accountId, security, notional);
+    }
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepository.java
@@ -1,0 +1,27 @@
+package finos.traderx.tradeservice.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+
+/**
+ * Append-only access to the best-execution audit trail.
+ *
+ * This extends the bare {@link Repository} marker rather than {@code JpaRepository} on
+ * purpose: inheriting {@code CrudRepository} would expose {@code delete}, {@code deleteAll}
+ * and {@code saveAll}-style mutation to any caller in the service. Only the four methods
+ * declared here exist.
+ */
+public interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
+
+    OrderDecisionAudit save(OrderDecisionAudit auditRecord);
+
+    Optional<OrderDecisionAudit> findById(String id);
+
+    List<OrderDecisionAudit> findByCorrelationId(String correlationId);
+
+    List<OrderDecisionAudit> findByAccountId(Integer accountId);
+}

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -7,6 +7,25 @@ reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_
 
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 
+# The best-execution audit trail is persisted in the shared TraderX database, alongside the
+# trades it explains, rather than in a service-local store.
+spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=${DATABASE_DBUSER:sa}
+spring.datasource.password=${DATABASE_DBPASS:sa}
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+# MiFID II RTS 27/28 best-execution audit trail (TRX-104). Single kill switch, on in dev.
+audit.best-execution.enabled=${BEST_EXECUTION_AUDIT_ENABLED:true}
+audit.best-execution.limit.id=${BEST_EXECUTION_LIMIT_ID:DEFAULT-ACCOUNT-NOTIONAL}
+audit.best-execution.limit.type=${BEST_EXECUTION_LIMIT_TYPE:ACCOUNT_NOTIONAL}
+audit.best-execution.limit.value=${BEST_EXECUTION_LIMIT_VALUE:5000000.0000}
+audit.best-execution.limit.effective-from=${BEST_EXECUTION_LIMIT_EFFECTIVE_FROM:2024-01-01T00:00:00Z}
+audit.best-execution.pricing.reference-price=${BEST_EXECUTION_REFERENCE_PRICE:100.0000}
+audit.best-execution.pricing.source=${BEST_EXECUTION_PRICE_SOURCE:CONFIGURED_STATIC_REFERENCE_PRICE}
+
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000
 

--- a/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/audit/OrderDecisionAuditServiceTest.java
@@ -1,0 +1,115 @@
+package finos.traderx.tradeservice.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.TradeSide;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+import finos.traderx.tradeservice.repository.OrderDecisionAuditRepository;
+
+class OrderDecisionAuditServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-08-12T09:15:30.123456Z");
+
+    private OrderDecisionAuditRepository repository;
+    private BestExecutionAuditProperties properties;
+    private OrderDecisionAuditService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(OrderDecisionAuditRepository.class);
+        when(repository.save(any(OrderDecisionAudit.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        properties = new BestExecutionAuditProperties();
+        properties.getPricing().setReferencePrice(new BigDecimal("12.5000"));
+        properties.getLimit().setValue(new BigDecimal("1000000.0000"));
+        properties.getLimit().setEffectiveFrom(Instant.parse("2025-04-01T00:00:00Z"));
+        service = new OrderDecisionAuditService(repository, properties,
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    void recordsAnAcceptedDecisionWithNotionalPriceAndLimitSnapshot() {
+        TradeOrder order = new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 400);
+
+        OrderDecisionAudit record = service.recordDecision(order, "CORR-1", DecisionOutcome.ACCEPTED,
+                DecisionReason.VALIDATED, "user01");
+
+        assertNotNull(record.getId());
+        assertEquals("CORR-1", record.getCorrelationId());
+        assertEquals("ORDER-1", record.getOrderId());
+        assertEquals(22214, record.getAccountId());
+        assertEquals("IBM", record.getSecurity());
+        assertEquals("Buy", record.getSide());
+        assertEquals(400, record.getQuantity());
+        assertEquals(new BigDecimal("12.5000"), record.getPrice());
+        assertEquals(0, new BigDecimal("5000.0000").compareTo(record.getNotional()));
+        assertEquals("CONFIGURED_STATIC_REFERENCE_PRICE", record.getPriceSource());
+        assertEquals(DecisionOutcome.ACCEPTED, record.getDecision());
+        assertEquals(DecisionReason.VALIDATED, record.getReasonCode());
+        assertEquals("DEFAULT-ACCOUNT-NOTIONAL", record.getLimitId());
+        assertEquals("ACCOUNT_NOTIONAL", record.getLimitType());
+        assertEquals(new BigDecimal("1000000.0000"), record.getLimitValue());
+        assertEquals(Instant.parse("2025-04-01T00:00:00Z"), record.getLimitEffectiveFrom());
+        assertEquals("user01", record.getSubmittedBy());
+        assertEquals(Instant.parse("2026-08-12T09:15:30.123Z"), record.getDecisionTimestamp());
+    }
+
+    @Test
+    void recordsARejectedDecisionForAnOrderThatNeverExists() {
+        TradeOrder order = new TradeOrder("ORDER-2", 99999, "NOSUCH", TradeSide.Sell, 10);
+
+        service.recordDecision(order, "CORR-2", DecisionOutcome.REJECTED, DecisionReason.ACCOUNT_NOT_FOUND, "user03");
+
+        ArgumentCaptor<OrderDecisionAudit> captor = ArgumentCaptor.forClass(OrderDecisionAudit.class);
+        verify(repository).save(captor.capture());
+        OrderDecisionAudit record = captor.getValue();
+        assertEquals(DecisionOutcome.REJECTED, record.getDecision());
+        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, record.getReasonCode());
+        assertEquals(99999, record.getAccountId());
+        assertEquals("CORR-2", record.getCorrelationId());
+        assertEquals("user03", record.getSubmittedBy());
+    }
+
+    @Test
+    void writesNothingWhenTheFeatureFlagIsOff() {
+        properties.setEnabled(false);
+
+        assertNull(service.recordDecision(new TradeOrder("ORDER-3", 22214, "IBM", TradeSide.Buy, 1), "CORR-3",
+                DecisionOutcome.ACCEPTED, DecisionReason.VALIDATED, "user01"));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void auditRecordExposesNoMutatorsAndTheRepositoryExposesNoDeletes() {
+        for (Method method : OrderDecisionAudit.class.getDeclaredMethods()) {
+            assertTrue(!method.getName().startsWith("set"),
+                    "OrderDecisionAudit must stay append-only but declares " + method.getName());
+        }
+        for (Method method : OrderDecisionAuditRepository.class.getMethods()) {
+            assertTrue(!method.getName().toLowerCase().contains("delete")
+                    && !method.getName().toLowerCase().contains("remove"),
+                    "Audit repository must expose no delete path but declares " + method.getName());
+        }
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/controller/TradeOrderControllerAuditTest.java
@@ -1,0 +1,142 @@
+package finos.traderx.tradeservice.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import finos.traderx.messaging.Publisher;
+import finos.traderx.tradeservice.audit.OrderDecisionAuditService;
+import finos.traderx.tradeservice.exceptions.ResourceNotFoundException;
+import finos.traderx.tradeservice.model.TradeOrder;
+import finos.traderx.tradeservice.model.TradeSide;
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+
+/**
+ * Every exit path from the submission endpoint must leave exactly one audit record behind,
+ * including the paths where a downstream lookup could not be performed at all.
+ */
+class TradeOrderControllerAuditTest {
+
+    private static final String REFERENCE_DATA_URL = "http://reference-data";
+    private static final String ACCOUNT_URL = "http://account-service";
+
+    private OrderDecisionAuditService auditService;
+    private Publisher<TradeOrder> publisher;
+    private RestTemplate restTemplate;
+    private MockRestServiceServer downstream;
+    private TradeOrderController controller;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        auditService = mock(OrderDecisionAuditService.class);
+        publisher = mock(Publisher.class);
+        restTemplate = new RestTemplate();
+        downstream = MockRestServiceServer.bindTo(restTemplate).build();
+        controller = new TradeOrderController(publisher, auditService, restTemplate);
+        ReflectionTestUtils.setField(controller, "referenceDataServiceAddress", REFERENCE_DATA_URL);
+        ReflectionTestUtils.setField(controller, "accountServiceAddress", ACCOUNT_URL);
+    }
+
+    private TradeOrder order() {
+        return new TradeOrder("ORDER-1", 22214, "IBM", TradeSide.Buy, 100);
+    }
+
+    private DecisionReason capturedReason(DecisionOutcome expectedOutcome) {
+        ArgumentCaptor<DecisionReason> reason = ArgumentCaptor.forClass(DecisionReason.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), eq(expectedOutcome), reason.capture(),
+                anyString());
+        return reason.getValue();
+    }
+
+    @Test
+    void anAcceptedOrderIsAuditedAndCarriesACorrelationId() throws Exception {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withSuccess("{\"id\":22214,\"displayName\":\"Test\"}", MediaType.APPLICATION_JSON));
+
+        TradeOrder submitted = controller.createTradeOrder(order(), "user01").getBody();
+
+        assertNotNull(submitted.getCorrelationId());
+        assertEquals(DecisionReason.VALIDATED, capturedReason(DecisionOutcome.ACCEPTED));
+        verify(publisher).publish(eq("/trades"), any(TradeOrder.class));
+    }
+
+    @Test
+    void anUnknownSecurityIsAuditedAsRejected() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.SECURITY_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anUnknownAccountIsAuditedAsRejected() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withSuccess("{\"ticker\":\"IBM\",\"companyName\":\"IBM\"}", MediaType.APPLICATION_JSON));
+        downstream.expect(requestTo(ACCOUNT_URL + "/account/22214"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.ACCOUNT_NOT_FOUND, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anOrderRefusedBecauseAValidationServiceFailedIsStillAudited() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM")).andRespond(withServerError());
+
+        assertThrows(RuntimeException.class, () -> controller.createTradeOrder(order(), "user01"));
+
+        assertEquals(DecisionReason.VALIDATION_UNAVAILABLE, capturedReason(DecisionOutcome.REJECTED));
+    }
+
+    @Test
+    void anOverlongSubmittingUserIsTruncatedToTheAuditColumnWidth() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.createTradeOrder(order(), "u".repeat(200)));
+
+        ArgumentCaptor<String> submittedBy = ArgumentCaptor.forClass(String.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
+                any(DecisionReason.class), submittedBy.capture());
+        assertEquals(50, submittedBy.getValue().length());
+    }
+
+    @Test
+    void anAnonymousSubmissionIsRecordedAsUnknownRatherThanNotAtAll() {
+        downstream.expect(requestTo(REFERENCE_DATA_URL + "/stocks/IBM"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResourceNotFoundException.class, () -> controller.createTradeOrder(order(), null));
+
+        ArgumentCaptor<String> submittedBy = ArgumentCaptor.forClass(String.class);
+        verify(auditService).recordDecision(any(TradeOrder.class), anyString(), any(DecisionOutcome.class),
+                any(DecisionReason.class), submittedBy.capture());
+        assertEquals("UNKNOWN", submittedBy.getValue());
+    }
+}

--- a/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
+++ b/trade-service/src/test/java/finos/traderx/tradeservice/repository/OrderDecisionAuditRepositoryTest.java
@@ -1,0 +1,67 @@
+package finos.traderx.tradeservice.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import finos.traderx.tradeservice.model.audit.DecisionOutcome;
+import finos.traderx.tradeservice.model.audit.DecisionReason;
+import finos.traderx.tradeservice.model.audit.EvaluatedLimit;
+import finos.traderx.tradeservice.model.audit.OrderDecisionAudit;
+
+@DataJpaTest
+class OrderDecisionAuditRepositoryTest {
+
+    @Autowired
+    private OrderDecisionAuditRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private OrderDecisionAudit rejectedRecord(String id, String correlationId) {
+        return new OrderDecisionAudit(id, correlationId, "ORDER-" + id, 22214, "IBM", "Buy", 100,
+                new BigDecimal("10.0000"), "CONFIGURED_STATIC_REFERENCE_PRICE", new BigDecimal("1000.0000"),
+                DecisionOutcome.REJECTED, DecisionReason.SECURITY_NOT_FOUND,
+                new EvaluatedLimit("DEFAULT-ACCOUNT-NOTIONAL", "ACCOUNT_NOTIONAL", new BigDecimal("5000000.0000"),
+                        Instant.parse("2024-01-01T00:00:00Z")),
+                "user01", Instant.parse("2026-08-12T09:15:30.123Z"));
+    }
+
+    @Test
+    void persistsAndRetrievesADecisionByCorrelationId() {
+        repository.save(rejectedRecord("A1", "CORR-A"));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<OrderDecisionAudit> found = repository.findByCorrelationId("CORR-A");
+
+        assertEquals(1, found.size());
+        assertEquals(DecisionOutcome.REJECTED, found.get(0).getDecision());
+        assertEquals(Instant.parse("2026-08-12T09:15:30.123Z"), found.get(0).getDecisionTimestamp());
+    }
+
+    @Test
+    void aPersistedDecisionCannotBeUpdated() throws Exception {
+        OrderDecisionAudit saved = repository.save(rejectedRecord("A2", "CORR-B"));
+        entityManager.flush();
+
+        Field decision = OrderDecisionAudit.class.getDeclaredField("decision");
+        decision.setAccessible(true);
+        decision.set(saved, DecisionOutcome.ACCEPTED);
+        entityManager.flush();
+        entityManager.clear();
+
+        OrderDecisionAudit reloaded = repository.findById("A2").orElseThrow();
+        assertEquals(DecisionOutcome.REJECTED, reloaded.getDecision());
+        assertTrue(reloaded.isNew());
+    }
+}

--- a/web-front-end/angular/main/app/accounts/user/assign-user.component.ts
+++ b/web-front-end/angular/main/app/accounts/user/assign-user.component.ts
@@ -25,7 +25,7 @@ export class AssignUserToAccountComponent implements OnInit {
         this.users$ = new Observable((observer: Observer<string | undefined>) => {
             observer.next(this.search as string | undefined);
         }).pipe(
-            switchMap<string, Observable<User[]>>((query: string) => {
+            switchMap<string | undefined, Observable<User[]>>((query?: string) => {
                 if (query && query.length > 2) {
                     return this.userService.getUsers(query).pipe(
                         map((data: User[]) => data || []),

--- a/web-front-end/angular/main/app/model/audit.model.ts
+++ b/web-front-end/angular/main/app/model/audit.model.ts
@@ -1,0 +1,43 @@
+export enum Decision {
+    Accepted = 'ACCEPTED',
+    Rejected = 'REJECTED'
+}
+
+export interface OrderDecision {
+    id: string;
+    correlationId: string;
+    orderId?: string;
+    accountId?: number;
+    security?: string;
+    side?: string;
+    quantity?: number;
+    price?: number;
+    priceSource?: string;
+    notional?: number;
+    decision: Decision;
+    reasonCode: string;
+    limitId?: string;
+    limitType?: string;
+    limitValue?: number;
+    limitEffectiveFrom?: string;
+    submittedBy?: string;
+    decisionTimestamp: string;
+}
+
+export interface AuditPage {
+    content: OrderDecision[];
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+}
+
+export interface AuditQuery {
+    accountId?: number;
+    security?: string;
+    decision?: Decision | '';
+    from?: string;
+    to?: string;
+    page?: number;
+    size?: number;
+}

--- a/web-front-end/angular/main/app/service/audit.service.ts
+++ b/web-front-end/angular/main/app/service/audit.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { AuditPage, AuditQuery } from '../model/audit.model';
+import { environment } from 'main/environments/environment';
+
+/**
+ * Read side of the best-execution audit trail, served by position-service. There is no write
+ * method here and there should not be one: the record is evidence, not application state.
+ */
+@Injectable({
+    providedIn: 'root'
+})
+export class AuditService {
+    private decisionsUrl = `${environment.positionsUrl}/audit/decisions`;
+
+    constructor(private http: HttpClient) { }
+
+    getDecisions(query: AuditQuery): Observable<AuditPage> {
+        let params = new HttpParams();
+        Object.entries(query).forEach(([key, value]) => {
+            if (value !== undefined && value !== null && value !== '') {
+                params = params.set(key, String(value));
+            }
+        });
+        return this.http.get<AuditPage>(this.decisionsUrl, { params }).pipe(
+            catchError(this.handleError)
+        );
+    }
+
+    private handleError(error: HttpErrorResponse) {
+        console.error(error);
+        return throwError(() => error);
+    }
+}

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
@@ -53,7 +53,7 @@
         (gridReady)="onGridReady($event)">
     </ag-grid-angular>
 
-    <div class="compliance-paging" *ngIf="!unavailable && !error">
+    <div class="compliance-paging" *ngIf="!unavailable && !error && !awaitingAccount">
         <button type="button" class="btn btn-sm btn-outline-secondary" (click)="previousPage()"
             [disabled]="page === 0">Previous</button>
         <span class="compliance-paging-label">

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
@@ -48,7 +48,7 @@
         </ng-template>
     </div>
 
-    <ag-grid-angular *ngIf="!unavailable && !error" style="width: 100%; height: 350px;" class="ag-theme-alpine"
+    <ag-grid-angular *ngIf="!unavailable && !error && !isEmpty && !awaitingAccount" style="width: 100%; height: 350px;" class="ag-theme-alpine"
         [columnDefs]="columnDefs" [defaultColDef]="defaultColDef" [rowData]="decisions" [getRowClass]="getRowClass"
         (gridReady)="onGridReady($event)">
     </ag-grid-angular>

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
@@ -17,11 +17,11 @@
             </select>
         </label>
         <label class="filter">
-            <span>From</span>
+            <span>From (UTC)</span>
             <input type="datetime-local" class="form-control form-control-sm" name="from" [(ngModel)]="from" />
         </label>
         <label class="filter">
-            <span>To</span>
+            <span>To (UTC)</span>
             <input type="datetime-local" class="form-control form-control-sm" name="to" [(ngModel)]="to" />
         </label>
         <label class="filter filter-check">
@@ -36,7 +36,12 @@
     </div>
     <div class="compliance-state compliance-state-error" *ngIf="error">{{ error }}</div>
     <div class="compliance-state" *ngIf="isEmpty">
-        No order decisions recorded yet. Every submitted order, accepted or rejected, will appear here.
+        <ng-container *ngIf="filtered; else nothingRecorded">
+            No order decisions match these filters. Widen the range or clear a filter &mdash; nothing has been removed.
+        </ng-container>
+        <ng-template #nothingRecorded>
+            No order decisions recorded yet. Every submitted order, accepted or rejected, will appear here.
+        </ng-template>
     </div>
 
     <ag-grid-angular *ngIf="!unavailable && !error" style="width: 100%; height: 350px;" class="ag-theme-alpine"

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
@@ -1,0 +1,56 @@
+<div class="compliance-blotter">
+    <div class="compliance-header">
+        <h5>Order decisions</h5>
+        <span class="compliance-retention">Read-only. Retained under MiFID II Art. 16(6) / RTS 27-28.</span>
+    </div>
+
+    <form class="compliance-filters" (ngSubmit)="applyFilters()">
+        <label class="filter">
+            <span>Security</span>
+            <input type="text" class="form-control form-control-sm" name="security" [(ngModel)]="security"
+                placeholder="e.g. AAPL" />
+        </label>
+        <label class="filter">
+            <span>Decision</span>
+            <select class="form-select form-select-sm" name="decision" [(ngModel)]="decision">
+                <option *ngFor="let option of decisionOptions" [value]="option.value">{{ option.label }}</option>
+            </select>
+        </label>
+        <label class="filter">
+            <span>From</span>
+            <input type="datetime-local" class="form-control form-control-sm" name="from" [(ngModel)]="from" />
+        </label>
+        <label class="filter">
+            <span>To</span>
+            <input type="datetime-local" class="form-control form-control-sm" name="to" [(ngModel)]="to" />
+        </label>
+        <label class="filter filter-check">
+            <input type="checkbox" class="form-check-input" name="limitToAccount" [(ngModel)]="limitToAccount" />
+            <span>Selected account only</span>
+        </label>
+        <button type="submit" class="btn btn-sm btn-primary" id="applyComplianceFilters">Apply</button>
+    </form>
+
+    <div class="compliance-state" *ngIf="unavailable">
+        The compliance audit query is switched off in this environment.
+    </div>
+    <div class="compliance-state compliance-state-error" *ngIf="error">{{ error }}</div>
+    <div class="compliance-state" *ngIf="isEmpty">
+        No order decisions recorded yet. Every submitted order, accepted or rejected, will appear here.
+    </div>
+
+    <ag-grid-angular *ngIf="!unavailable && !error" style="width: 100%; height: 350px;" class="ag-theme-alpine"
+        [columnDefs]="columnDefs" [defaultColDef]="defaultColDef" [rowData]="decisions" [getRowClass]="getRowClass"
+        (gridReady)="onGridReady($event)">
+    </ag-grid-angular>
+
+    <div class="compliance-paging" *ngIf="!unavailable && !error">
+        <button type="button" class="btn btn-sm btn-outline-secondary" (click)="previousPage()"
+            [disabled]="page === 0">Previous</button>
+        <span class="compliance-paging-label">
+            Page {{ totalPages === 0 ? 0 : page + 1 }} of {{ totalPages }} &mdash; {{ totalElements }} decision(s)
+        </span>
+        <button type="button" class="btn btn-sm btn-outline-secondary" (click)="nextPage()"
+            [disabled]="page + 1 >= totalPages">Next</button>
+    </div>
+</div>

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.html
@@ -31,6 +31,10 @@
         <button type="submit" class="btn btn-sm btn-primary" id="applyComplianceFilters">Apply</button>
     </form>
 
+    <div class="compliance-state" *ngIf="awaitingAccount && !unavailable">
+        Select an account to see its order decisions, or untick "Selected account only" to search the whole trail.
+    </div>
+
     <div class="compliance-state" *ngIf="unavailable">
         The compliance audit query is switched off in this environment.
     </div>

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.scss
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.scss
@@ -1,0 +1,69 @@
+.compliance-blotter {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    .compliance-header {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+
+        h5 {
+            margin: 0;
+        }
+    }
+
+    .compliance-retention {
+        font-size: 12px;
+        opacity: 0.7;
+    }
+
+    .compliance-filters {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        gap: 10px;
+
+        .filter {
+            display: flex;
+            flex-direction: column;
+            font-size: 12px;
+
+            &-check {
+                flex-direction: row;
+                align-items: center;
+                gap: 6px;
+            }
+        }
+    }
+
+    .compliance-state {
+        padding: 10px;
+        border: 1px dashed #adb5bd;
+        border-radius: 4px;
+        font-size: 14px;
+
+        &-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    }
+
+    .compliance-paging {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 13px;
+    }
+}
+
+// ag-grid renders rows outside this component's view encapsulation.
+::ng-deep .ag-theme-alpine .compliance-row-rejected {
+    background-color: rgba(220, 53, 69, 0.12);
+    border-left: 3px solid #dc3545;
+}
+
+::ng-deep .ag-theme-alpine .compliance-cell-rejected {
+    color: #b02a37;
+    font-weight: 600;
+}

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -79,6 +79,21 @@ describe('ComplianceBlotterComponent', () => {
         expect(auditService.lastQuery?.accountId).toBeUndefined();
     });
 
+    it('should page the result set that was applied, not whatever is typed in the boxes', () => {
+        component.account = dummyAccounts[0];
+        component.security = 'AAPL';
+        component.applyFilters();
+        component.totalPages = 3;
+
+        component.security = 'MSFT';
+        component.limitToAccount = false;
+        component.nextPage();
+
+        expect(auditService.lastQuery?.security).toEqual('AAPL');
+        expect(auditService.lastQuery?.accountId).toEqual(dummyAccounts[0].id);
+        expect(auditService.lastQuery?.page).toEqual(1);
+    });
+
     it('should mark rejected rows as distinct and accepted rows as ordinary', () => {
         expect(component.getRowClass({ data: decision('a1', Decision.Rejected) } as any))
             .toEqual('compliance-row-rejected');

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { AgGridModule } from 'ag-grid-angular';
+import { of, throwError } from 'rxjs';
+
+import { ComplianceBlotterComponent } from './compliance-blotter.component';
+import { AuditService } from 'main/app/service/audit.service';
+import { AuditPage, AuditQuery, Decision, OrderDecision } from 'main/app/model/audit.model';
+import { accounts as dummyAccounts } from 'main/app/test-utils/mocks.service';
+
+const decision = (id: string, outcome: Decision): OrderDecision => ({
+    id,
+    correlationId: `corr-${id}`,
+    accountId: 11413,
+    security: 'AAPL',
+    side: 'Buy',
+    quantity: 100,
+    decision: outcome,
+    reasonCode: outcome === Decision.Rejected ? 'ACCOUNT_LIMIT_BREACHED' : 'VALIDATED',
+    decisionTimestamp: '2026-01-01T10:00:00Z'
+});
+
+class MockAuditService {
+    lastQuery?: AuditQuery;
+    page: AuditPage = { content: [], page: 0, size: 25, totalElements: 0, totalPages: 0 };
+
+    getDecisions(query: AuditQuery) {
+        this.lastQuery = query;
+        return of({ ...this.page, page: query.page ?? 0 });
+    }
+}
+
+describe('ComplianceBlotterComponent', () => {
+    let component: ComplianceBlotterComponent;
+    let fixture: ComponentFixture<ComplianceBlotterComponent>;
+    let auditService: MockAuditService;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ComplianceBlotterComponent],
+            imports: [AgGridModule, FormsModule],
+            providers: [{ provide: AuditService, useClass: MockAuditService }]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ComplianceBlotterComponent);
+        component = fixture.componentInstance;
+        auditService = TestBed.inject(AuditService) as unknown as MockAuditService;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should show an empty state before any order has been submitted', () => {
+        expect(component.isEmpty).toBeTrue();
+        expect(fixture.nativeElement.textContent).toContain('No order decisions recorded yet');
+    });
+
+    it('should mark rejected rows as distinct and accepted rows as ordinary', () => {
+        expect(component.getRowClass({ data: decision('a1', Decision.Rejected) } as any))
+            .toEqual('compliance-row-rejected');
+        expect(component.getRowClass({ data: decision('a2', Decision.Accepted) } as any)).toEqual('');
+    });
+
+    it('should send the active filters to the audit service and reset to the first page', () => {
+        component.page = 3;
+        component.security = ' AAPL ';
+        component.decision = Decision.Rejected;
+        component.applyFilters();
+
+        expect(auditService.lastQuery).toEqual(jasmine.objectContaining({
+            security: 'AAPL',
+            decision: Decision.Rejected,
+            page: 0,
+            size: 25
+        }));
+    });
+
+    it('should scope to the selected account only while that filter is on', () => {
+        component.account = dummyAccounts[0];
+        component.applyFilters();
+        expect(auditService.lastQuery?.accountId).toEqual(dummyAccounts[0].id);
+
+        component.limitToAccount = false;
+        component.applyFilters();
+        expect(auditService.lastQuery?.accountId).toBeUndefined();
+    });
+
+    it('should page forward and back within the reported page count', () => {
+        auditService.page = { content: [], page: 0, size: 25, totalElements: 60, totalPages: 3 };
+        component.applyFilters();
+
+        component.nextPage();
+        expect(auditService.lastQuery?.page).toEqual(1);
+        component.previousPage();
+        expect(auditService.lastQuery?.page).toEqual(0);
+
+        component.previousPage();
+        expect(auditService.lastQuery?.page).toEqual(0);
+    });
+
+    it('should report the feature being switched off rather than an error', () => {
+        spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 503 })));
+        component.applyFilters();
+
+        expect(component.unavailable).toBeTrue();
+        expect(component.error).toEqual('');
+    });
+
+    it('should surface a failure to load without clearing into an empty state', () => {
+        spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 500 })));
+        component.applyFilters();
+
+        expect(component.unavailable).toBeFalse();
+        expect(component.error).toBeTruthy();
+        expect(component.isEmpty).toBeFalse();
+    });
+});

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -142,6 +142,27 @@ describe('ComplianceBlotterComponent', () => {
         expect(auditService.lastQuery?.to).toEqual('2026-04-01T00:00:00.000Z');
     });
 
+    it('should not call the whole trail empty when only the selected account has no decisions', () => {
+        component.account = dummyAccounts[0];
+        component.applyFilters();
+        fixture.detectChanges();
+
+        expect(component.isEmpty).toBeTrue();
+        expect(fixture.nativeElement.textContent).toContain('No order decisions match these filters');
+        expect(fixture.nativeElement.textContent).not.toContain('No order decisions recorded yet');
+    });
+
+    it('should say what is wrong with a rejected filter rather than report an outage', () => {
+        component.account = dummyAccounts[0];
+        spyOn(auditService, 'getDecisions').and.returnValue(
+            throwError(() => ({ status: 400, error: { message: "'to' must not be before 'from'" } })));
+
+        component.applyFilters();
+
+        expect(component.error).toEqual("'to' must not be before 'from'");
+        expect(component.unavailable).toBeFalse();
+    });
+
     it('should say a filter matched nothing rather than that nothing was recorded', () => {
         component.account = dummyAccounts[0];
         component.security = 'MSFT';

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -94,6 +94,22 @@ describe('ComplianceBlotterComponent', () => {
         expect(auditService.lastQuery?.page).toEqual(1);
     });
 
+    it('should drop a stale failure when it goes back to asking for an account', () => {
+        component.limitToAccount = false;
+        spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 503 })));
+        component.applyFilters();
+        expect(component.unavailable).toBeTrue();
+
+        component.limitToAccount = true;
+        component.applyFilters();
+        fixture.detectChanges();
+
+        expect(component.unavailable).toBeFalse();
+        expect(component.error).toEqual('');
+        expect(fixture.nativeElement.textContent).toContain('Select an account');
+        expect(fixture.nativeElement.textContent).not.toContain('decision(s)');
+    });
+
     it('should mark rejected rows as distinct and accepted rows as ordinary', () => {
         expect(component.getRowClass({ data: decision('a1', Decision.Rejected) } as any))
             .toEqual('compliance-row-rejected');

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -100,6 +100,33 @@ describe('ComplianceBlotterComponent', () => {
         expect(auditService.lastQuery?.page).toEqual(0);
     });
 
+    it('should not query across every account while the view claims to be scoped to one', () => {
+        expect(auditService.lastQuery).toBeUndefined();
+
+        component.account = dummyAccounts[0];
+        component.ngOnChanges({ account: { currentValue: dummyAccounts[0], previousValue: undefined } } as any);
+        expect(auditService.lastQuery?.accountId).toEqual(dummyAccounts[0].id);
+    });
+
+    it('should read the date filters as UTC, matching the timestamps it displays', () => {
+        component.from = '2026-01-01T10:00';
+        component.to = '2026-04-01T00:00';
+        component.applyFilters();
+
+        expect(auditService.lastQuery?.from).toEqual('2026-01-01T10:00:00.000Z');
+        expect(auditService.lastQuery?.to).toEqual('2026-04-01T00:00:00.000Z');
+    });
+
+    it('should say a filter matched nothing rather than that nothing was recorded', () => {
+        component.security = 'MSFT';
+        component.applyFilters();
+        fixture.detectChanges();
+
+        expect(component.isEmpty).toBeTrue();
+        expect(fixture.nativeElement.textContent).toContain('No order decisions match these filters');
+        expect(fixture.nativeElement.textContent).not.toContain('No order decisions recorded yet');
+    });
+
     it('should report the feature being switched off rather than an error', () => {
         spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 503 })));
         component.applyFilters();

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.spec.ts
@@ -53,8 +53,30 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should show an empty state before any order has been submitted', () => {
+        component.limitToAccount = false;
+        component.applyFilters();
+        fixture.detectChanges();
+
         expect(component.isEmpty).toBeTrue();
         expect(fixture.nativeElement.textContent).toContain('No order decisions recorded yet');
+    });
+
+    it('should ask for an account rather than claim the trail is empty before it has queried', () => {
+        expect(auditService.lastQuery).toBeUndefined();
+        expect(component.isEmpty).toBeFalse();
+        expect(fixture.nativeElement.textContent).toContain('Select an account');
+        expect(fixture.nativeElement.textContent).not.toContain('No order decisions recorded yet');
+    });
+
+    it('should never query every account while "Selected account only" is ticked', () => {
+        component.security = 'AAPL';
+        component.applyFilters();
+        component.nextPage();
+        expect(auditService.lastQuery).toBeUndefined();
+
+        component.limitToAccount = false;
+        component.applyFilters();
+        expect(auditService.lastQuery?.accountId).toBeUndefined();
     });
 
     it('should mark rejected rows as distinct and accepted rows as ordinary', () => {
@@ -64,6 +86,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should send the active filters to the audit service and reset to the first page', () => {
+        component.account = dummyAccounts[0];
         component.page = 3;
         component.security = ' AAPL ';
         component.decision = Decision.Rejected;
@@ -88,6 +111,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should page forward and back within the reported page count', () => {
+        component.account = dummyAccounts[0];
         auditService.page = { content: [], page: 0, size: 25, totalElements: 60, totalPages: 3 };
         component.applyFilters();
 
@@ -109,6 +133,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should read the date filters as UTC, matching the timestamps it displays', () => {
+        component.account = dummyAccounts[0];
         component.from = '2026-01-01T10:00';
         component.to = '2026-04-01T00:00';
         component.applyFilters();
@@ -118,6 +143,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should say a filter matched nothing rather than that nothing was recorded', () => {
+        component.account = dummyAccounts[0];
         component.security = 'MSFT';
         component.applyFilters();
         fixture.detectChanges();
@@ -128,6 +154,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should report the feature being switched off rather than an error', () => {
+        component.account = dummyAccounts[0];
         spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 503 })));
         component.applyFilters();
 
@@ -136,6 +163,7 @@ describe('ComplianceBlotterComponent', () => {
     });
 
     it('should surface a failure to load without clearing into an empty state', () => {
+        component.account = dummyAccounts[0];
         spyOn(auditService, 'getDecisions').and.returnValue(throwError(() => ({ status: 500 })));
         component.applyFilters();
 

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -38,6 +38,11 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
     /** Whether the last query narrowed the trail, so an empty result can be explained as such. */
     filtered = false;
 
+    /** No claim is made about the trail until a query has actually answered. */
+    loaded = false;
+
+    private requested = false;
+
     readonly decisionOptions = [
         { value: '', label: 'All decisions' },
         { value: Decision.Rejected, label: 'Rejected only' },
@@ -67,13 +72,9 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
 
     constructor(private auditService: AuditService) { }
 
-    /**
-     * Nothing is loaded until the account arrives if the view claims to be scoped to it. An
-     * unscoped first query would briefly show other accounts' decisions under a ticked
-     * "Selected account only", which on a compliance screen is not a cosmetic problem.
-     */
+    /** ngOnChanges runs first when the account is already bound, and has already loaded by then. */
     ngOnInit() {
-        if (!this.limitToAccount || this.account) {
+        if (!this.requested) {
             this.load();
         }
     }
@@ -117,11 +118,28 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
         return params.data?.decision === Decision.Rejected ? 'compliance-row-rejected' : '';
     }
 
+    /**
+     * The view cannot honestly answer "scoped to the selected account" before an account exists,
+     * and querying every account under a ticked box is the wrong way to fill the gap.
+     */
+    get awaitingAccount(): boolean {
+        return this.limitToAccount && !this.account;
+    }
+
     get isEmpty(): boolean {
-        return !this.loading && !this.unavailable && !this.error && this.decisions.length === 0;
+        return this.loaded && !this.loading && !this.unavailable && !this.error && this.decisions.length === 0;
     }
 
     private load() {
+        if (this.awaitingAccount) {
+            this.decisions = [];
+            this.totalElements = 0;
+            this.totalPages = 0;
+            this.loaded = false;
+            return;
+        }
+
+        this.requested = true;
         this.filtered = Boolean(this.security?.trim() || this.decision || this.from || this.to);
         const query: AuditQuery = {
             accountId: this.limitToAccount ? this.account?.id : undefined,
@@ -143,6 +161,7 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
                 this.totalPages = result.totalPages;
                 this.unavailable = false;
                 this.loading = false;
+                this.loaded = true;
             },
             error: (response) => {
                 this.decisions = [];
@@ -151,6 +170,7 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
                 this.unavailable = response?.status === 503;
                 this.error = this.unavailable ? '' : 'Could not load the audit trail.';
                 this.loading = false;
+                this.loaded = false;
             }
         });
     }

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -1,4 +1,5 @@
 import { ColDef, GridApi, GridReadyEvent, RowClassParams } from 'ag-grid-community';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Account } from 'main/app/model/account.model';
 import { AuditQuery, Decision, OrderDecision } from 'main/app/model/audit.model';
@@ -140,9 +141,10 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
         }
 
         this.requested = true;
-        this.filtered = Boolean(this.security?.trim() || this.decision || this.from || this.to);
+        const accountId = this.limitToAccount ? this.account?.id : undefined;
+        this.filtered = Boolean(accountId || this.security?.trim() || this.decision || this.from || this.to);
         const query: AuditQuery = {
-            accountId: this.limitToAccount ? this.account?.id : undefined,
+            accountId,
             security: this.security?.trim() || undefined,
             decision: this.decision || undefined,
             from: this.toInstant(this.from),
@@ -163,16 +165,30 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
                 this.loading = false;
                 this.loaded = true;
             },
-            error: (response) => {
+            error: (response: HttpErrorResponse) => {
                 this.decisions = [];
                 this.totalElements = 0;
                 this.totalPages = 0;
                 this.unavailable = response?.status === 503;
-                this.error = this.unavailable ? '' : 'Could not load the audit trail.';
+                this.error = this.errorFor(response);
                 this.loading = false;
                 this.loaded = false;
             }
         });
+    }
+
+    /**
+     * A 400 is the caller's own filter coming back at them - the range the wrong way round, say -
+     * so it says what to change rather than implying the trail is unreachable.
+     */
+    private errorFor(response: HttpErrorResponse): string {
+        if (response?.status === 503) {
+            return '';
+        }
+        if (response?.status === 400 && response.error?.message) {
+            return response.error.message;
+        }
+        return 'Could not load the audit trail.';
     }
 
     /**

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -35,6 +35,9 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
     totalElements = 0;
     totalPages = 0;
 
+    /** Whether the last query narrowed the trail, so an empty result can be explained as such. */
+    filtered = false;
+
     readonly decisionOptions = [
         { value: '', label: 'All decisions' },
         { value: Decision.Rejected, label: 'Rejected only' },
@@ -64,8 +67,15 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
 
     constructor(private auditService: AuditService) { }
 
+    /**
+     * Nothing is loaded until the account arrives if the view claims to be scoped to it. An
+     * unscoped first query would briefly show other accounts' decisions under a ticked
+     * "Selected account only", which on a compliance screen is not a cosmetic problem.
+     */
     ngOnInit() {
-        this.load();
+        if (!this.limitToAccount || this.account) {
+            this.load();
+        }
     }
 
     ngOnChanges(change: SimpleChanges) {
@@ -112,6 +122,7 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
     }
 
     private load() {
+        this.filtered = Boolean(this.security?.trim() || this.decision || this.from || this.to);
         const query: AuditQuery = {
             accountId: this.limitToAccount ? this.account?.id : undefined,
             security: this.security?.trim() || undefined,
@@ -144,8 +155,13 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
         });
     }
 
-    /** The datetime-local inputs are wall clock; the record is UTC, so say so explicitly. */
+    /**
+     * The datetime-local inputs are wall clock with no zone. They are read as UTC, matching the
+     * column the reviewer is reading the timestamps from: parsing them in the browser's zone
+     * would shift a quarter-boundary query by the viewer's offset and quietly drop the records
+     * at each end of the window they asked for.
+     */
     private toInstant(value: string): string | undefined {
-        return value ? new Date(value).toISOString() : undefined;
+        return value ? new Date(`${value}Z`).toISOString() : undefined;
     }
 }

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -5,6 +5,14 @@ import { Account } from 'main/app/model/account.model';
 import { AuditQuery, Decision, OrderDecision } from 'main/app/model/audit.model';
 import { AuditService } from 'main/app/service/audit.service';
 
+interface AppliedFilters {
+    limitToAccount: boolean;
+    security?: string;
+    decision?: Decision;
+    from?: string;
+    to?: string;
+}
+
 /**
  * Compliance view over the retained order decisions (MiFID II Art. 16(6), RTS 27/28).
  *
@@ -44,6 +52,14 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
 
     private requested = false;
 
+    /**
+     * The filters the current page was fetched with. Paging reads these rather than the live
+     * inputs, so pressing Next after typing in a box cannot quietly return page 2 of a different
+     * result set - on an evidential screen a reviewer would have no way to tell records had been
+     * skipped. Editing a box changes nothing until Apply.
+     */
+    private applied: AppliedFilters = this.currentFilters();
+
     readonly decisionOptions = [
         { value: '', label: 'All decisions' },
         { value: Decision.Rejected, label: 'Rejected only' },
@@ -82,13 +98,14 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
 
     ngOnChanges(change: SimpleChanges) {
         if (change.account?.currentValue && change.account.currentValue !== change.account.previousValue
-            && this.limitToAccount) {
+            && this.applied.limitToAccount) {
             this.page = 0;
             this.load();
         }
     }
 
     applyFilters() {
+        this.applied = this.currentFilters();
         this.page = 0;
         this.load();
     }
@@ -124,7 +141,7 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
      * and querying every account under a ticked box is the wrong way to fill the gap.
      */
     get awaitingAccount(): boolean {
-        return this.limitToAccount && !this.account;
+        return this.applied.limitToAccount && !this.account;
     }
 
     get isEmpty(): boolean {
@@ -141,14 +158,15 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
         }
 
         this.requested = true;
-        const accountId = this.limitToAccount ? this.account?.id : undefined;
-        this.filtered = Boolean(accountId || this.security?.trim() || this.decision || this.from || this.to);
+        const applied = this.applied;
+        const accountId = applied.limitToAccount ? this.account?.id : undefined;
+        this.filtered = Boolean(accountId || applied.security || applied.decision || applied.from || applied.to);
         const query: AuditQuery = {
             accountId,
-            security: this.security?.trim() || undefined,
-            decision: this.decision || undefined,
-            from: this.toInstant(this.from),
-            to: this.toInstant(this.to),
+            security: applied.security,
+            decision: applied.decision,
+            from: applied.from,
+            to: applied.to,
             page: this.page,
             size: this.pageSize
         };
@@ -199,5 +217,15 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
      */
     private toInstant(value: string): string | undefined {
         return value ? new Date(`${value}Z`).toISOString() : undefined;
+    }
+
+    private currentFilters(): AppliedFilters {
+        return {
+            limitToAccount: this.limitToAccount,
+            security: this.security?.trim() || undefined,
+            decision: this.decision || undefined,
+            from: this.toInstant(this.from),
+            to: this.toInstant(this.to)
+        };
     }
 }

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -1,0 +1,151 @@
+import { ColDef, GridApi, GridReadyEvent, RowClassParams } from 'ag-grid-community';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Account } from 'main/app/model/account.model';
+import { AuditQuery, Decision, OrderDecision } from 'main/app/model/audit.model';
+import { AuditService } from 'main/app/service/audit.service';
+
+/**
+ * Compliance view over the retained order decisions (MiFID II Art. 16(6), RTS 27/28).
+ *
+ * Read-only by construction: no row is editable, and there is no action on this view that can
+ * change or remove a record.
+ */
+@Component({
+    selector: 'app-compliance-blotter',
+    templateUrl: './compliance-blotter.component.html',
+    styleUrls: ['./compliance-blotter.component.scss']
+})
+export class ComplianceBlotterComponent implements OnInit, OnChanges {
+    @Input() account?: Account;
+
+    decisions: OrderDecision[] = [];
+    gridApi: GridApi;
+    loading = false;
+    unavailable = false;
+    error = '';
+
+    limitToAccount = true;
+    security = '';
+    decision: Decision | '' = '';
+    from = '';
+    to = '';
+
+    page = 0;
+    pageSize = 25;
+    totalElements = 0;
+    totalPages = 0;
+
+    readonly decisionOptions = [
+        { value: '', label: 'All decisions' },
+        { value: Decision.Rejected, label: 'Rejected only' },
+        { value: Decision.Accepted, label: 'Accepted only' }
+    ];
+
+    columnDefs: ColDef[] = [
+        {
+            headerName: 'DECISION',
+            field: 'decision',
+            width: 120,
+            cellClass: (params) => params.value === Decision.Rejected ? 'compliance-cell-rejected' : ''
+        },
+        { headerName: 'REASON', field: 'reasonCode', width: 200 },
+        { headerName: 'TIMESTAMP (UTC)', field: 'decisionTimestamp', width: 200 },
+        { headerName: 'ACCOUNT', field: 'accountId', width: 110 },
+        { headerName: 'SECURITY', field: 'security', width: 110 },
+        { headerName: 'SIDE', field: 'side', width: 90 },
+        { headerName: 'QUANTITY', field: 'quantity', width: 110 },
+        { headerName: 'NOTIONAL', field: 'notional', width: 130 },
+        { headerName: 'LIMIT APPLIED', field: 'limitValue', width: 140 },
+        { headerName: 'SUBMITTED BY', field: 'submittedBy', width: 140 },
+        { headerName: 'CORRELATION ID', field: 'correlationId', width: 300 }
+    ];
+
+    defaultColDef: ColDef = { sortable: false, resizable: true };
+
+    constructor(private auditService: AuditService) { }
+
+    ngOnInit() {
+        this.load();
+    }
+
+    ngOnChanges(change: SimpleChanges) {
+        if (change.account?.currentValue && change.account.currentValue !== change.account.previousValue
+            && this.limitToAccount) {
+            this.page = 0;
+            this.load();
+        }
+    }
+
+    applyFilters() {
+        this.page = 0;
+        this.load();
+    }
+
+    nextPage() {
+        if (this.page + 1 < this.totalPages) {
+            this.page += 1;
+            this.load();
+        }
+    }
+
+    previousPage() {
+        if (this.page > 0) {
+            this.page -= 1;
+            this.load();
+        }
+    }
+
+    onGridReady(params: GridReadyEvent) {
+        this.gridApi = params.api;
+    }
+
+    /**
+     * Rejections are the records a regulator asks about first, so they are the ones the eye
+     * should land on.
+     */
+    getRowClass(params: RowClassParams): string {
+        return params.data?.decision === Decision.Rejected ? 'compliance-row-rejected' : '';
+    }
+
+    get isEmpty(): boolean {
+        return !this.loading && !this.unavailable && !this.error && this.decisions.length === 0;
+    }
+
+    private load() {
+        const query: AuditQuery = {
+            accountId: this.limitToAccount ? this.account?.id : undefined,
+            security: this.security?.trim() || undefined,
+            decision: this.decision || undefined,
+            from: this.toInstant(this.from),
+            to: this.toInstant(this.to),
+            page: this.page,
+            size: this.pageSize
+        };
+
+        this.loading = true;
+        this.error = '';
+        this.auditService.getDecisions(query).subscribe({
+            next: (result) => {
+                this.decisions = result.content;
+                this.page = result.page;
+                this.totalElements = result.totalElements;
+                this.totalPages = result.totalPages;
+                this.unavailable = false;
+                this.loading = false;
+            },
+            error: (response) => {
+                this.decisions = [];
+                this.totalElements = 0;
+                this.totalPages = 0;
+                this.unavailable = response?.status === 503;
+                this.error = this.unavailable ? '' : 'Could not load the audit trail.';
+                this.loading = false;
+            }
+        });
+    }
+
+    /** The datetime-local inputs are wall clock; the record is UTC, so say so explicitly. */
+    private toInstant(value: string): string | undefined {
+        return value ? new Date(value).toISOString() : undefined;
+    }
+}

--- a/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
+++ b/web-front-end/angular/main/app/trade/compliance-blotter/compliance-blotter.component.ts
@@ -153,7 +153,10 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
             this.decisions = [];
             this.totalElements = 0;
             this.totalPages = 0;
+            this.page = 0;
             this.loaded = false;
+            this.error = '';
+            this.unavailable = false;
             return;
         }
 
@@ -187,6 +190,7 @@ export class ComplianceBlotterComponent implements OnInit, OnChanges {
                 this.decisions = [];
                 this.totalElements = 0;
                 this.totalPages = 0;
+                this.page = 0;
                 this.unavailable = response?.status === 503;
                 this.error = this.errorFor(response);
                 this.loading = false;

--- a/web-front-end/angular/main/app/trade/trade-blotter/trade-blotter.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/trade-blotter/trade-blotter.component.spec.ts
@@ -66,8 +66,8 @@ describe('TradeBlotterComponent', () => {
 
     });
 
-    it('getRowNodeId should return id from trade data', () => {
-        expect(component.getRowNodeId(trades[0])).toEqual(trades[0].id);
+    it('getRowId should return id from trade data', () => {
+        expect(component.getRowId({ data: trades[0] } as any)).toEqual(`Trade-${trades[0].id}`);
     });
 
 });

--- a/web-front-end/angular/main/app/trade/trade.component.html
+++ b/web-front-end/angular/main/app/trade/trade.component.html
@@ -31,8 +31,15 @@
         </div>
     </div>
 
-    <div class="trade-blotter">
-        <app-trade-blotter [account]="accountModel" class="trade-blotter-items me-2"> </app-trade-blotter>
-        <app-position-blotter [account]="accountModel" class="position-blotter-items"> </app-position-blotter>
-    </div>
+    <tabset>
+        <tab heading="Blotter" id="blotterTab">
+            <div class="trade-blotter">
+                <app-trade-blotter [account]="accountModel" class="trade-blotter-items me-2"> </app-trade-blotter>
+                <app-position-blotter [account]="accountModel" class="position-blotter-items"> </app-position-blotter>
+            </div>
+        </tab>
+        <tab heading="Compliance" id="complianceTab">
+            <app-compliance-blotter [account]="accountModel"></app-compliance-blotter>
+        </tab>
+    </tabset>
 </div>

--- a/web-front-end/angular/main/app/trade/trade.component.spec.ts
+++ b/web-front-end/angular/main/app/trade/trade.component.spec.ts
@@ -4,6 +4,7 @@ import { TradeComponent } from './trade.component';
 import { FormsModule } from '@angular/forms';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { ModalModule } from 'ngx-bootstrap/modal';
+import { TabsModule } from 'ngx-bootstrap/tabs';
 import { AccountService } from '../service/account.service';
 import { MockAccountService, MockSymbolService, accounts } from '../test-utils/mocks.service';
 import { SymbolService } from '../service/symbols.service';
@@ -24,7 +25,8 @@ describe('TradeComponent', () => {
                 FormsModule,
                 DropdownModule,
                 ModalModule.forRoot(),
-                AlertModule.forRoot()
+                AlertModule.forRoot(),
+                TabsModule.forRoot()
             ],
             providers: [
                 {

--- a/web-front-end/angular/main/app/trade/trade.module.ts
+++ b/web-front-end/angular/main/app/trade/trade.module.ts
@@ -12,9 +12,11 @@ import { DropdownModule } from '../dropdown/dropdown.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ComplianceBlotterComponent } from './compliance-blotter/compliance-blotter.component';
 
 @NgModule({
-  declarations: [TradeComponent, TradeTicketComponent, TradeBlotterComponent, PositionBlotterComponent],
+  declarations: [TradeComponent, TradeTicketComponent, TradeBlotterComponent, PositionBlotterComponent, ComplianceBlotterComponent],
   imports: [
     CommonModule,
     AgGridModule,
@@ -22,9 +24,10 @@ import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
     TypeaheadModule.forRoot(),
     ModalModule.forRoot(),
     AlertModule.forRoot(),
+    TabsModule.forRoot(),
     FormsModule,
     DropdownModule
   ],
-  exports: [TradeComponent, TradeTicketComponent, TradeBlotterComponent]
+  exports: [TradeComponent, TradeTicketComponent, TradeBlotterComponent, ComplianceBlotterComponent]
 })
 export class TradeModule { }


### PR DESCRIPTION
## Summary

**TRX-105.** TRX-104 made TraderX *keep* the record of why every order was accepted or rejected. On its own that satisfies nothing: MiFID II Art. 16(6) and the RTS 27/28 best-execution regime require the firm to *produce* that record on request, for a named account or instrument, over a stated window, up to five years after the fact. A regulator or an internal compliance officer asking "show me every order you refused for this account in Q3" cannot be answered by a table nobody can query. This PR adds the query side and puts it in front of the people who get asked the question.

Two pieces:

* `GET /audit/decisions` on **position-service** — filters on account, security, decision and a half-open time range, paged, newest first, read-only.
* A **Compliance** tab on the blotter, alongside the existing Blotter tab, listing retained decisions with the rejections visually distinct.

**Why position-service and not trade-service.** The blotter already reads trades and positions from position-service, so the query side belongs next to the other read models. trade-service stays on the hot path of order submission and keeps only the write: a five-year compliance query that scans history has no business sharing a service with order entry.

### The query

One JPQL query with optional parameters, rather than a Specification:

```java
// extends Repository, NOT JpaRepository - as TRX-104's writer-side repository does.
// JpaSpecificationExecutor is avoided for the same reason: it carries delete(Specification).
interface OrderDecisionAuditRepository extends Repository<OrderDecisionAudit, String> {
    @Query("""
        select a from OrderDecisionAudit a
        where (:accountId is null or a.accountId = :accountId)
          and (:security  is null or a.security  = :security)
          and (:decision  is null or a.decision  = :decision)
          and (:from is null or a.decisionTimestamp >= :from)   -- inclusive
          and (:to   is null or a.decisionTimestamp <  :to)     -- exclusive
        order by a.decisionTimestamp desc, a.id desc""", countQuery = "...")
    Page<OrderDecisionAudit> search(...);
}
```

Three details that are deliberate rather than incidental:

* **The sort is `(decisionTimestamp desc, id desc)`, not timestamp alone.** TRX-104 truncates the decision timestamp to milliseconds, so two decisions can share one. A page boundary falling between two equal timestamps under an unstable sort silently drops or duplicates a record — which is the one failure mode an evidential query must not have.
* **The range is half-open** (`from` inclusive, `to` exclusive), so consecutive windows a reviewer requests neither overlap nor lose the decision that landed exactly on the boundary.
* **Paged and indexed, not `SELECT *`.** Three composite indexes are added alongside TRX-104's, each anchored on `DecisionTimestamp` because every supported filter is read as "this filter, over this window, newest first":

```sql
CREATE INDEX IDX_OrderDecisionAudit_Time          ON OrderDecisionAudit (DecisionTimestamp, ID);
CREATE INDEX IDX_OrderDecisionAudit_Security_Time ON OrderDecisionAudit (Security, DecisionTimestamp);
CREATE INDEX IDX_OrderDecisionAudit_Decision_Time ON OrderDecisionAudit (Decision, DecisionTimestamp);
-- (Account, DecisionTimestamp) and (CorrelationID) already come from TRX-104.
```

`size` is clamped server-side to `audit.query.max-page-size`, so a caller cannot ask for the whole table. The From/To filters are wall clock read as **UTC**, matching the `TIMESTAMP (UTC)` column the reviewer copies them from — parsing them in the browser's zone would shift a quarter-boundary query by the viewer's offset and drop records at each end. The `security` filter is trimmed and compared case-insensitively (`upper(a.security) = :security`): a reviewer who types `aapl` must not be told there are no decisions for that instrument, and an empty page is indistinguishable from a genuine absence. That costs `IDX_OrderDecisionAudit_Security_Time` on that one predicate — the right trade for a filter whose wrong answer is silent.

### Read-only in the mapping, not in a comment

position-service builds on TRX-104's schema rather than a parallel one: the same `ORDERDECISIONAUDIT` table, mapped here as a **read-only projection**. Following the repo's existing convention (`Trade` is already mapped separately in position-service and trade-processor, there is no shared module), the mapping is duplicated — but stripped to a reader: `@Immutable`, every column `updatable = false`, no setters, no public constructor, and a repository that declares only `search`. There is no POST/PUT/PATCH/DELETE on `/audit`, no delete button and no "clear" action in the UI. A record that can be amended after the fact is not evidence.

One intentional divergence from TRX-104's mapping: `reasonCode` is a `String` here, not the `DecisionReason` enum. trade-service can add a reason code without position-service being redeployed, and a reader that throws on an unrecognised value would hide exactly the decisions it exists to surface.

### The tab

The existing side-by-side blotters move inside a `<tabset>` as a **Blotter** tab — unchanged in content — with **Compliance** next to it. Rejections carry a row class and a coloured decision cell, because the rejected orders are the ones a regulator asks about first. The tab renders before any order has been submitted: an explicit empty state ("No order decisions recorded yet…"), not a bare grid. It distinguishes three empty cases, because on an evidential screen they are not the same statement: nothing recorded, nothing matching the current filters, and no account selected yet — in the last case it asks for one rather than querying every account under a ticked "Selected account only". With the feature switched off the tab says so rather than showing an error.

### Acceptance criteria

* **Existing behaviour preserved.** No change to trade or position endpoints; the Blotter tab is the same two grids.
* **Tested.** 17 new tests: 8 against H2 covering filters, the half-open range, paging without loss or duplication, the size clamp, rejected input, case-insensitive ticker matching, the empty page and the limit-snapshot passthrough; 7 on the controller for filter binding (`from`/`to` require an offset, as Spring's instant converter insists), unknown `decision` → 400, an unparseable `from`/`accountId` → 400 (a mistyped filter is a bad request, not the "audit trail unavailable" a controller-local catch-all would otherwise report) the flag off → 503, and JSON error bodies that echo neither the caller's input, nor Spring's internal type names, nor a persistence failure's message. 18 new Angular specs cover the three empty states, the rejected row class, filter/paging behaviour (paging uses the filters that were applied, not whatever is currently typed), UTC filter handling, account scoping and the disabled and failed states. `./gradlew build` passes for position-service, and `./gradlew test` for trade-service.
* **No new runtime dependency.** JPA, H2 and ag-grid/ngx-bootstrap were already on the respective classpaths; `<tabset>` comes from the `ngx-bootstrap` already in use.
* **Configuration externalised, single flag, on in dev:** `audit.query.enabled` (`AUDIT_QUERY_ENABLED`), plus `audit.query.default-page-size` and `audit.query.max-page-size`. Off → `503` from the API and a plain "switched off in this environment" in the tab.

### Branch and merge order

Based on **`devin/1786519039-trx-104-best-execution-audit`** (PR #99), not on `main`, because this ticket queries 104's table and its schema had to exist first. **#99 must merge before this PR.** Until it does, the diff shown here includes 104's commits; once #99 lands, what remains is only the change described above.

Demo pack files (`demo/barclays-agentic-factory/`) are deliberately not included — they live on an unmerged branch.

## Decisions and open questions

**Decided — the query lives in position-service, the write stays in trade-service.** Two services now map the same table, which is a real cost: a column rename in TRX-104 breaks this reader at runtime, not at compile time. The alternative — a shared persistence module — is a bigger change to a repo that has deliberately duplicated `Trade` for the same reason. Worth revisiting if a third service reads the audit trail.

**Decided — offset paging, not a keyset cursor.** `page`/`size` matches what the blotter needs and reads naturally in the UI. On a genuinely five-year table, deep offsets (`page=50000`) degrade, because the database still walks the skipped rows. The stable `(timestamp, id)` sort is exactly the key a cursor would use, so switching later is mechanical. Not done now: it would add API surface the demo path never exercises.

**Decided — the feature flag returns `503`, not an empty result.** "Switched off" and "nothing to show" are different facts, and a compliance view that answers "no decisions" when it is simply disabled is worse than one that refuses to answer.

**Decided — Angular only.** The ticket names `web-front-end`, and the Angular app is the one with the tabbed blotter this ticket describes. The React app under `web-front-end/react` renders two ungrouped grids with no tab strip; adding the tab there means inventing that chrome first. **Open question:** does the demo need the React front end at parity, or is Angular the front end the room will be looking at?

**★ Open — no authorisation on the endpoint.** `/audit/decisions` is `@CrossOrigin("*")` and unauthenticated, consistent with every other TraderX endpoint. For a demo that is fine; for anything real, an audit trail carrying `submittedBy` and account-level notionals is precisely the data that needs a compliance-role check in front of it. I did not add an auth scheme, because inventing one for this endpoint alone would be inconsistent with the rest of the platform and is a decision the customer's IAM standards should drive.

**★ Open — the `Submitted by` column will read `UNKNOWN` for every row.** TRX-104 takes the submitting user from an `X-TraderX-User` header, and nothing in the repo sends it. Wiring the Angular ticket to send the selected user is a two-line change, but it would replace "always UNKNOWN" with "whatever the client claims" — the header is unauthenticated, so the column would look like attribution without being it. Left honest rather than plausible, pending the same IAM decision as the item above.

**★ Open — retention and immutability are asserted by the application, not the database.** The mapping and the repository make it impossible to write from the application. The H2 credentials in `application.properties` can still `UPDATE` the table by hand, and `initialSchema.sql` drops and recreates `OrderDecisionAudit` on every database start — so the trail does not even survive a restart. Both are consistent with how the rest of TraderX seeds its demo data, and both sit awkwardly beside the five-year framing that motivates the indexes. Real evidential retention needs database-level grants (or WORM storage) and a documented five-year retention policy. Out of scope here, but it should not be presented as solved.

**★ Open — two pre-existing breaks on `main` had to be touched to satisfy "builds pass for the touched services".** Neither is caused by this work; both blocked verifying it:

1. `ng build --configuration production` fails on `main` with `TS2345` in `assign-user.component.ts` (an `OperatorFunction<string, …>` given a `string | undefined` source). Fixed with a one-line type widening.
2. `ng test` does not compile on `main`: `trade-blotter.component.spec.ts` calls `component.getRowNodeId(...)`, which was renamed to `getRowId` in the ag-grid upgrade. Fixed by calling the current method.

Both fixes are one line each and are called out here rather than folded in quietly. Separately, `TradeBlotterComponent should call getTrades on changes and set trades` fails with "1 timer(s) still in the queue" — I confirmed this fails on `main` too (with only the two compile fixes applied and none of this ticket's changes), so I have left it alone rather than widening this PR into a test-suite repair. Should that be its own ticket?


Link to Devin session: https://app.devin.ai/sessions/76a0a2788b644b68b553c9b0068b33b1
Requested by: @chrischappell-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/101?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/traderXCognitiondemos/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/traderxcognitiondemos/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->